### PR TITLE
fix(app): accommodate carat options in variants in Bambuser component

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
 	"homepage": "https://www.spinellikilcollin.com",
 	"license": "NONE",
 	"scripts": {
+		"dev": "NODE_ENV=development next dev",
 		"start": "DEBUG=app* next",
 		"start:prod": "NODE_ENV=production next",
 		"start:debug": "NODE_OPTIONS='--inspect' DEBUG=app* next dev",

--- a/app/src/providers/BambuserProvider/setupProductData.ts
+++ b/app/src/providers/BambuserProvider/setupProductData.ts
@@ -11,6 +11,8 @@ const CURRENCY = 'USD'
 const LOCALE = 'en-us'
 
 const findVariant = (product: ShopifyProduct, key: string) => {
+  console.log('product:', product)
+  console.log('key:', key)
   const v = product?.variants?.find((variant) => {
     return variant?.title === key
   })
@@ -27,18 +29,32 @@ const findVariantById = (product: ShopifyProduct, key: string) => {
 const findOptionIndex = (
   options: Maybe<ShopifyProductOptionValue>[],
   key: string,
+  caratOptions?: Maybe<ShopifyProductOptionValue>[],
+  caratKey?: string,
 ): number => {
-  return options.findIndex((element) => {
-    return element?.value === key
-  })
+  if (caratOptions && caratKey) {
+    console.log('FINDOPTIONINDEX OPTIONS ARRAY', options)
+    console.log('FINDOPTIONINDEX KEY', key)
+    console.log('FINDOPTIONINDEX CARAT OPTIONS ARRAY', caratOptions)
+    console.log('FINDOPTIONINDEX CARAT KEY', caratKey)
+    return caratOptions.findIndex((element) => {
+      return element?.value === caratKey
+    })
+  } else {
+    return options.findIndex((element) => {
+      return element?.value === key
+    })
+  }
 }
 
 const hydrateSize = (
   product: ShopifyProduct,
   s: any,
   color: string | null = '',
+  carat: string | null = '',
 ) => {
   const sizes = product?.options?.find((option) => {
+    console.log('SIZES OPTION', option)
     return option?.name === 'Size'
   })
   const lengths = product?.options?.find((option) => {
@@ -47,9 +63,55 @@ const hydrateSize = (
   const titles = product?.options?.find((option) => {
     return option?.name === 'Title'
   })
+  const carats = product?.options?.find((option) => {
+    return option?.name === 'Carat'
+  })
 
-  if (sizes && sizes.values && sizes.values.length > 0) {
-    return sizes?.values?.map((size) => {
+  console.log('CARAT', carat)
+  console.log('COLOR', color)
+
+  if (
+    sizes &&
+    sizes.values &&
+    sizes.values.length > 0 &&
+    carats &&
+    carats.values &&
+    carats.values.length > 0
+  ) {
+    console.log('CARATS', carats)
+    console.log('SIZES', sizes)
+    const variants = sizes?.values?.map((size) => {
+      console.log('MAPPED SIZE', size)
+      const key =
+        color == 'No Color Option'
+          ? `${size?.value}`
+          : color && carat
+          ? `${color}${DELIMITER}${carat}${DELIMITER}${size?.value}`
+          : color
+          ? `${color}${DELIMITER}${size?.value}`
+          : `${size?.value}`
+
+      const variant = findVariant(product, key)
+      if (!variant) return
+      if (
+        variant &&
+        variant.sourceData &&
+        variant.sourceData.availableForSale
+      ) {
+        const price = variant.sourceData.priceV2
+        console.log('S PRICE', price)
+        return s()
+          .name(size?.value)
+          .price((pr) =>
+            pr.currency(price?.currencyCode).current(price?.amount),
+          )
+          .sku(variant.shopifyVariantID)
+      }
+    })
+    console.log('VARIANTS', variants)
+    return variants
+  } else if (sizes && sizes.values && sizes.values.length > 0) {
+    const variants = sizes?.values?.map((size) => {
       const key =
         color == 'No Color Option'
           ? `${size?.value}`
@@ -72,6 +134,7 @@ const hydrateSize = (
           .sku(variant.shopifyVariantID)
       }
     })
+    console.log('VARIANTS', variants)
   } else if (lengths && lengths.values && lengths.values.length > 0) {
     return lengths?.values?.map((length) => {
       const key =
@@ -143,6 +206,8 @@ const getImageUrls = (variant: ShopifyProductVariant): string[] => {
 }
 
 const hydrate = (product: ShopifyProduct, selectedIndex: number, v: any) => {
+  const hydratedVariants: any[] = []
+
   const colors = product?.options?.find((option) => {
     return option?.name === 'Color'
   })
@@ -155,11 +220,70 @@ const hydrate = (product: ShopifyProduct, selectedIndex: number, v: any) => {
     return option?.name === 'Length'
   })
 
+  const carats = product?.options?.find((option) => {
+    return option?.name === 'Carat'
+  })
+
   const titles = product?.options?.find((option) => {
     return option?.name === 'Title'
   })
 
-  if (colors && colors.values && colors.values.length > 0) {
+  if (
+    colors &&
+    colors.values &&
+    colors.values.length == 1 &&
+    carats &&
+    carats.values &&
+    carats.values.length > 0
+  ) {
+    const sizeValue =
+      sizes && sizes.values && sizes.values.length > 0
+        ? sizes.values[0]?.value
+        : ''
+    const lengthValue =
+      lengths && lengths.values && lengths.values.length > 0
+        ? lengths.values[0]?.value
+        : ''
+    const titleValue =
+      titles && titles.values && titles.values.length > 0
+        ? titles.values[0]?.value
+        : ''
+    const colorValue = colors?.values[0]?.value
+    const selected = carats.values.filter((_, index) => {
+      if (index == selectedIndex) console.log('SELECTED _', _)
+      return index === selectedIndex
+    })
+    const variants = selected.map((carat) => {
+      const caratValue = carat?.value
+
+      const key =
+        carats && sizeValue
+          ? `${colorValue}${DELIMITER}${caratValue}${DELIMITER}${sizeValue}`
+          : carats && lengthValue
+          ? `${colorValue}${DELIMITER}${caratValue}${DELIMITER}${lengthValue}`
+          : carats && titleValue
+          ? `${colorValue}${DELIMITER}${caratValue}${DELIMITER}${titleValue}`
+          : `${colorValue}${DELIMITER}${caratValue}`
+
+      console.log('hydrate() carat key', key)
+      const variant = findVariant(product, key)
+      console.log('VARIANT', variant)
+      if (!variant) return
+
+      const imageUrls = getImageUrls(variant)
+      console.log('IMAGE URLS', imageUrls)
+
+      const variable = v()
+        .attributes((a) => a.colorName(colorValue))
+        .imageUrls(imageUrls)
+        .sku(variant.shopifyVariantID)
+        .name(colorValue)
+        .sizes((s) => hydrateSize(product, s, colorValue, caratValue))
+    })
+    hydratedVariants.push(variants)
+    console.log('HYDRATED VARIANTS', hydratedVariants)
+    return variants
+  } else if (colors && colors.values && colors.values.length > 0) {
     const sizeValue =
       sizes && sizes.values && sizes.values.length > 0
         ? sizes.values[0]?.value
@@ -187,6 +311,7 @@ const hydrate = (product: ShopifyProduct, selectedIndex: number, v: any) => {
           ? `${colorValue}${DELIMITER}${titleValue}`
           : `${colorValue}${sizeValue}`
 
+      console.log('hydrate() color key', key)
       const variant = findVariant(product, key)
       if (!variant) return
 
@@ -266,22 +391,42 @@ export const setupProductData = (
 
   let index = 0
   let title = product.title
+  let carat = ''
   const currentVariant = findVariantById(product, hash)
 
   const colors = product?.options?.find((option) => {
     return option?.name === 'Color'
   })
 
+  const carats = product?.options?.find((option) => {
+    return option?.name === 'Carat'
+  })
+
   if (currentVariant) {
     const parts = currentVariant.title?.split(DELIMITER)
 
     if (colors && colors.values) {
-      if (parts && parts?.length > 0) {
+      if (
+        carats &&
+        carats.values &&
+        carats.values.length > 0 &&
+        parts &&
+        parts?.length > 0
+      ) {
         title = parts[0].trim()
+        carat = parts[1].trim()
+        if (title) {
+          index = findOptionIndex(colors.values, title, carats.values, carat)
+        }
+      } else if (parts && parts?.length > 0) {
+        title = parts[0].trim()
+        if (title) {
+          index = findOptionIndex(colors.values, title)
+        }
       }
-      if (title) {
-        index = findOptionIndex(colors.values, title)
-      }
+      console.log('CURRENT VARIANT TITLE', title)
+      console.log('CURRENT VARIANT CARAT', carat)
+      console.log('CURRENT VARIANT INDEX', index)
       index = index > -1 ? index : 0
     }
   }

--- a/app/src/providers/BambuserProvider/setupProductData.ts
+++ b/app/src/providers/BambuserProvider/setupProductData.ts
@@ -279,6 +279,7 @@ const hydrate = (product: ShopifyProduct, selectedIndex: number, v: any) => {
         .sku(variant.shopifyVariantID)
         .name(colorValue)
         .sizes((s) => hydrateSize(product, s, colorValue, caratValue))
+      return variable
     })
     hydratedVariants.push(variants)
     console.log('HYDRATED VARIANTS', hydratedVariants)


### PR DESCRIPTION
the Bambuser component is not hydrating product variants with Carat options properly...

(you can see the error on production site (and this preview branch) when you click the bottom button that is supposed to load the associated product variants from the video in the modal component.