### PR TITLE
fix(app): additional check on undefined images

### DIFF
--- a/app/src/components/Image/utils.ts
+++ b/app/src/components/Image/utils.ts
@@ -165,7 +165,7 @@ const isShopifyImage = (image: ImageType): image is ShopifySourceImage =>
 export const getImageDetails = (
   image?: ImageType | null | void,
 ): ImageDetails | null => {
-  if (!image) return null
+  if (!image || !image?.__typename) return null
   if (isShopifyImage(image)) return getShopifyImageDetails(image)
   if (isSanityRawImage(image)) return getSanityImageDetails(image)
   if (isSanityImage(image)) return getSanityImageDetails(image)


### PR DESCRIPTION
**issue:** “Sonny” and “7mm” search terms result in blank page…
https://www.notion.so/goodidea/Search-Errors-2eade84f80e8440281567ad895299b9d

---

The product "Custom Sonny for Hannah size 7.5 - 50% payment" seems to be missing an image (see below), resulting in errors on search. This adds an additional check against undefined images.

<img width="944" alt="image" src="https://user-images.githubusercontent.com/6518748/197913041-f19a7c3a-0e4f-4f4b-acb7-f19a3d0160e8.png">
