### PR TITLE
fix(app): Disable draggable state for ProductThumbnail link

### DIFF
--- a/app/src/components/Product/ProductThumbnail.tsx
+++ b/app/src/components/Product/ProductThumbnail.tsx
@@ -366,7 +366,7 @@ export const ProductThumbnail = ({
   return (
     <ProductThumb ref={containerRef} onClick={handleClick}>
       <Link href="/products/[productSlug]" as={linkAs}>
-        <a aria-label={'Link to ' + product.title}>
+        <a draggable="false" aria-label={'Link to ' + product.title}>
           {variantAnimation ? (
             <VideoWrapper hide={!playing}>
               <CloudinaryAnimation


### PR DESCRIPTION
This fixes carousel drag interactions on desktop by disabling the draggable state for the ProductThumbnail link. Previously on desktop, drag interaction for carousel was only working correctly if you clicked in-between the carousel elements.