### PR TITLE
feat:(app) hide in stock display and filter

### DIFF
--- a/app/src/components/Filter/Filter.tsx
+++ b/app/src/components/Filter/Filter.tsx
@@ -548,7 +548,7 @@ export const Filter = ({
                   active={Boolean(activeKey === filter._key)}
                   minimalDisplay={minimalDisplay}
                 >
-                  <InventoryFilter
+                  {/* <InventoryFilter
                     setKey={filter._key || 'some-key'}
                     filterSetState={filterSetStates.find(
                       (s) => s.key === filter._key,
@@ -558,7 +558,7 @@ export const Filter = ({
                     scrollGridIntoView={scrollGridIntoView}
                     inventoryFilter={filter}
                     active={Boolean(activeKey === filter._key)}
-                  />
+                  /> */}
                 </FilterWrapper>
               ) : null,
             )}

--- a/app/src/components/Product/ProductSwatches.tsx
+++ b/app/src/components/Product/ProductSwatches.tsx
@@ -82,11 +82,11 @@ export const OptionSwatches = ({
             ratio={1}
             sizes="40px"
           />
-          {isSwatchCurrentlyInStock(value, stockedOptions) ? (
+          {/* {isSwatchCurrentlyInStock(value, stockedOptions) ? (
             <InStockDot />
           ) : (
             ''
-          )}
+          )} */}
         </SwatchWrapper>
       ))}
     </SwatchesWrapper>

--- a/app/src/components/Product/ProductThumbnail.tsx
+++ b/app/src/components/Product/ProductThumbnail.tsx
@@ -397,12 +397,12 @@ export const ProductThumbnail = ({
                 my={0}
                 currentlyInStock={isProductCurrentlyInStock(product)}
               >
-                {isProductCurrentlyInStock(product) &&
+                {/* {isProductCurrentlyInStock(product) &&
                 !IsDisplayingSwatches(product) ? (
                   <InStockDot />
                 ) : (
                   ''
-                )}
+                )} */}
                 {product.title} |{' '}
                 <PriceWrapper>
                   <Price

--- a/app/src/views/ProductDetail/ProductDetail.tsx
+++ b/app/src/views/ProductDetail/ProductDetail.tsx
@@ -374,7 +374,7 @@ export const ProductDetail = ({ product }: Props) => {
                   )}
                 />
                 <ProductInfoWrapper>
-                  {variantsInStock?.length > 0 ? (
+                  {/* {variantsInStock?.length > 0 ? (
                     <StockedLabelMobile
                       hide={
                         !isSwatchCurrentlyInStock(
@@ -391,7 +391,7 @@ export const ProductDetail = ({ product }: Props) => {
                           : 'Ready to Ship in Select Sizes'}
                       </Heading>
                     </StockedLabelMobile>
-                  ) : null}
+                  ) : null} */}
                   <ProductVariantSelector
                     variants={variants}
                     currentVariant={currentVariant}

--- a/app/src/views/ProductDetail/components/ProductDetailHeader.tsx
+++ b/app/src/views/ProductDetail/components/ProductDetailHeader.tsx
@@ -108,7 +108,7 @@ export const ProductDetailHeader = ({
   return (
     <>
       <TitleWrapper product={product}>
-        {variantsInStock?.length > 0 ? (
+        {/* {variantsInStock?.length > 0 ? (
           <StockedLabel
             hide={
               !isSwatchCurrentlyInStock(
@@ -125,7 +125,7 @@ export const ProductDetailHeader = ({
                 : 'Ready to Ship in Select Sizes'}
             </Heading>
           </StockedLabel>
-        ) : null}
+        ) : null} */}
         <Heading level={3} weight={2} mb={{ xs: 1, md: 2 }}>
           {variantTitle || product.title}
         </Heading>


### PR DESCRIPTION
- hides inventory filter
- hides green `inStockDot`
- hides "Ready to Ship" headings

---

@beelaineo For now, I've commented out these features since we will be bringing them back soon. It would be good to make a quick pass on the site to make sure I got all of them. Also, we will want to remove "Shop In Stock" from the navigation in sanity. 