### PR TITLE
fix(app): undefined products on related carousel

### DIFF
--- a/app/src/components/Carousel/CollectionCarousel.tsx
+++ b/app/src/components/Carousel/CollectionCarousel.tsx
@@ -87,6 +87,10 @@ export const CollectionCarousel = ({ collection }: CollectionCarouselProps) => {
 
   const fetchedCollection = data?.allShopifyCollection[0]
 
+  const products = collectionProducts
+    ? collectionProducts
+    : definitely(fetchedCollection?.products)
+
   if (!products?.length) return null
 
   const initialSlide = viewportWidth < 650 ? 1 : 0

--- a/app/src/components/Carousel/CollectionCarousel.tsx
+++ b/app/src/components/Carousel/CollectionCarousel.tsx
@@ -1,16 +1,91 @@
 import * as React from 'react'
+import { gql } from 'graphql-tag'
 import { ShopifyCollection } from '../../types'
 import { Carousel } from './Carousel'
 import { ProductThumbnail } from '../Product'
 import { definitely, useViewportSize } from '../../utils'
+import { useLazyRequest, shopifySourceImageFragment } from '../../graphql'
+const { useEffect } = React
+
+const query = gql`
+  query CarouselCollectionQuery($collectionId: ID!) {
+    allShopifyCollection(where: { _id: { eq: $collectionId } }) {
+      __typename
+      _id
+      _type
+      _key
+      title
+      handle
+      archived
+      shopifyId
+      products {
+        __typename
+        _id
+        _key
+        title
+        hidden
+        hideFromSearch
+        handle
+        archived
+        shopifyId
+        minVariantPrice
+        maxVariantPrice
+        sourceData {
+          __typename
+          id
+          title
+          handle
+          tags
+          productType
+          images {
+            __typename
+            edges {
+              __typename
+              cursor
+              node {
+                ...ShopifySourceImageFragment
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  ${shopifySourceImageFragment}
+`
+
+interface Response {
+  allShopifyCollection: ShopifyCollection[]
+}
+interface Variables {
+  collectionId: string | null | undefined
+}
 
 interface CollectionCarouselProps {
   collection: ShopifyCollection
 }
 
 export const CollectionCarousel = ({ collection }: CollectionCarouselProps) => {
-  const products = collection?.products
+  const collectionProducts = collection?.products
   const { width: viewportWidth } = useViewportSize()
+
+  const variables = {
+    collectionId: collection._id,
+  }
+  const [getCarousel, response] = useLazyRequest<Response, Variables>(
+    query,
+    variables,
+  )
+  const { data } = response
+
+  useEffect(() => {
+    if (Boolean(data)) return
+    if (!variables.collectionId) return
+    if (collectionProducts && collectionProducts.length) return
+    getCarousel(variables)
+  }, [data])
+
+  const fetchedCollection = data?.allShopifyCollection[0]
 
   if (!products?.length) return null
 


### PR DESCRIPTION
**“Rings” carousel at the bottom of product detail pages have disappeared**
https://goodidea.notion.site/Rings-carousel-at-the-bottom-of-product-detail-pages-have-disappeared-970b37c04c364cd6862246147b9ff5aa

- https://github.com/beelaineo/spinellikilcollin.com/pull/230 removed carousel query from `CollectionCarousel` and added products to the `CarouselFragment`, allowing products to load in during page request. This worked in most carousel uses but not where products within a collection were undefined and needed to be fetched. This PR adds back in the query to CollectionCarousel component, and only runs the request if products within a collection are not already defined.


