### PR TITLE
chore(sanity): add deploy:graphql:staging script

### DIFF
--- a/sanity/package.json
+++ b/sanity/package.json
@@ -16,9 +16,11 @@
   "scripts": {
     "start": "sanity start",
     "test": "sanity check",
-    "deploy": "yarn deploy:graphql && yarn deploy:cms",
+    "deploy": "yarn deploy:graphql:production && yarn deploy:cms && yarn deploy:types",
     "deploy:cms": "sanity deploy",
-    "deploy:graphql": "sanity graphql deploy --generation gen2 --playground && yarn workspace spinellikilcollin-app generate-types",
+    "deploy:graphql:production": "sanity graphql deploy --generation gen2 --playground",
+    "deploy:graphql:staging": "sanity graphql deploy --dataset staging --generation gen2 --playground",
+    "deploy:types": "yarn workspace spinellikilcollin-app generate-types",
     "sync:export": "sanity dataset export production",
     "sync:reset": "sanity dataset delete staging && sanity dataset create staging",
     "sync:import": "sanity dataset import production.tar.gz staging --replace",


### PR DESCRIPTION
I had a failing build because my `.env.local` was pointed to `staging`; it turns out the graphQL endpoint for that dataset is out of date.

This adds a separate script for deploying the latest schema to the `staging` endpoint. This won't be run with from `yarn deploy`, that will still:

- deploy the studio instance
- deploy the graphql endpoint for `production`
- re-generate types