### PR TITLE
feat(app): improve Sentry

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -62,6 +62,7 @@
 		"react-hot-loader": "^4.13.1",
 		"ts-jest": "^27.1.5",
 		"ts-node": "^10.9.1",
+		"tsc-watch": "^6.0.0",
 		"typescript": "^4.9.4",
 		"typesync": "^0.9.2",
 		"utility-types": "^3.10.0"

--- a/app/pages/api/algoliaIndex.ts
+++ b/app/pages/api/algoliaIndex.ts
@@ -65,15 +65,6 @@ type SanityShopifyDocument = GroqShopifyProduct | GroqShopifyCollection
 const parseDocument = (doc: SanityShopifyDocument) => {
   try {
     switch (doc._type) {
-      // case 'page':
-      //   return {
-      //     objectID: doc._id,
-      //     type: doc._type,
-      //     body: blocksToText(doc.body || []),
-      //     title: doc.title,
-      //     slug: doc.slug.current,
-      //   }
-
       case 'shopifyProduct':
         const [allVariants] = unwindEdges(doc?.sourceData?.variants)
         const [images] = unwindEdges(doc?.sourceData?.images)
@@ -188,20 +179,11 @@ const parseDocument = (doc: SanityShopifyDocument) => {
           },
         }
 
-      // case 'shopifyCollection':
-      //   return {
-      //     objectID: doc._id,
-      //     type: doc._type,
-      //     description: doc?.sourceData?.description,
-      //     title: doc.title,
-      //     handle: doc.handle,
-      //     // document: doc,
-      //   }
       default:
         return null
     }
   } catch (e) {
-    Sentry.captureException(e)
+    Sentry.captureException(e, 'algolia_parse_error', { document: doc })
   }
 }
 
@@ -221,7 +203,7 @@ const handler: NextApiHandler = (req, res) =>
             //   JSON.parse(err?.transporterStackTrace[0].request.data).requests[9]
             //     .body.document.sourceData.variants,
             // )
-            Sentry.captureException(err)
+            Sentry.captureException(err, 'algolia_index_error')
           })
       })
 
@@ -236,7 +218,7 @@ const handler: NextApiHandler = (req, res) =>
       })
 
       const errorCb = (error: Error) => {
-        Sentry.captureException(error)
+        Sentry.captureException(error, 'algolia_index_error')
       }
 
       streamToRx(request(sanityExportURL).pipe(ndjson.parse()))
@@ -276,18 +258,6 @@ const handler: NextApiHandler = (req, res) =>
             const results = batchResults.flat()
             const totalLength = results.length
 
-            // .reduce(
-            //   // @ts-ignore
-            //   (count, batchResult) => {
-            //     console.log(batchResult)
-            //
-            //     count + batchResult.objectIDs.length
-            //   },
-            //   0,
-            // )
-            // console.log(objectIds[1])
-            // console.log({ objectIds })
-            // console.log(results[0])
             debug(
               `Updated ${totalLength} documents in ${batchResults.length} batches`,
             )
@@ -330,7 +300,7 @@ const handler: NextApiHandler = (req, res) =>
           errorCb,
         )
     } catch (err) {
-      Sentry.captureException(err)
+      Sentry.captureException(err, 'algolia_index_error')
     }
   })
 

--- a/app/pages/api/sitemap.xml.tsx
+++ b/app/pages/api/sitemap.xml.tsx
@@ -103,7 +103,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     })
   } catch (e) {
     console.error(e)
-    Sentry.captureException(e)
+    Sentry.captureException(e, 'sitemap_gen_error')
     res.status(500).end()
   }
 }

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -117,7 +117,6 @@ export const Homepage = ({ homepage }: HomepageProps) => {
       return <HomepageView homepage={homepage} />
     }
   } catch (e) {
-    Sentry.captureException(e)
     return <NotFound />
   }
 }
@@ -127,12 +126,19 @@ export const Homepage = ({ homepage }: HomepageProps) => {
  */
 
 export const getStaticProps: GetStaticProps = async () => {
-  const [response, shopData] = await Promise.all([
-    request<HomepageResponse>(homepageQuery),
-    requestShopData(),
-  ])
-  const homepage = response?.Homepage || null
-  return { props: { shopData, homepage }, revalidate: 10 }
+  try {
+    const [response, shopData] = await Promise.all([
+      request<HomepageResponse>(homepageQuery),
+      requestShopData(),
+    ])
+    const homepage = response?.Homepage || null
+    return { props: { shopData, homepage }, revalidate: 10 }
+  } catch (e) {
+    Sentry.captureException(e, 'next_static_props_error', {
+      route: 'index',
+    })
+    return { props: {}, revalidate: 1 }
+  }
 }
 
 export default Homepage

--- a/app/src/graphql/request.ts
+++ b/app/src/graphql/request.ts
@@ -33,7 +33,12 @@ export const request = async <R, V extends Variables = Variables>(
     return result
   } catch (err: any | unknown) {
     console.error(err?.response)
-    throw new Error(`Network error: Failed to connect to ${SANITY_GRAPHQL_URL}`)
+    const error =
+      err instanceof Error
+        ? err
+        : new Error(`Network error: Failed to connect to ${SANITY_GRAPHQL_URL}`)
+
+    throw error
   }
 }
 
@@ -51,8 +56,13 @@ export const requestTokenized = async <R, V extends Variables = Variables>(
     )
     return result
   } catch (err: any | unknown) {
-    console.error(err.response)
-    throw new Error(`Network error: Failed to connect to ${SANITY_GRAPHQL_URL}`)
+    console.error(err?.response)
+    const error =
+      err instanceof Error
+        ? err
+        : new Error(`Network error: Failed to connect to ${SANITY_GRAPHQL_URL}`)
+
+    throw error
   }
 }
 

--- a/app/src/graphql/request.ts
+++ b/app/src/graphql/request.ts
@@ -66,7 +66,7 @@ export const useRequest = <R, V extends Variables = Variables>(
       request<R>(q, variables),
     )
   } catch (e: any | unknown) {
-    handleError(e)
+    handleError(e, 'graphql_request_error', { query, variables })
   }
 }
 
@@ -93,7 +93,7 @@ export const useLazyRequest = <R, V extends Variables = Variables>(
       const result = await request<R>(query, variables)
       response.mutate(result, false)
     } catch (e: any | unknown) {
-      handleError(e)
+      handleError(e, 'graphql_request_error', { query, variables })
     }
   }
 

--- a/app/src/hooks/useSanityQuery/useSanityQuery.ts
+++ b/app/src/hooks/useSanityQuery/useSanityQuery.ts
@@ -99,7 +99,7 @@ export const useSanityQuery = <
       // @ts-ignore
       return r
     } catch (err: any | unknown) {
-      handleError(err)
+      handleError(err, 'sanity_query_error', { query, params })
       // @ts-ignore
       return []
     }

--- a/app/src/providers/BambuserProvider/utils.ts
+++ b/app/src/providers/BambuserProvider/utils.ts
@@ -58,7 +58,7 @@ export const queryByHandle = async (handle: string) => {
     const product = products && products.length ? products[0] : null
     return product
   } catch (e) {
-    Sentry.captureException(e)
+    Sentry.captureException(e, 'shopify_query_error')
     return null
   }
 }

--- a/app/src/providers/CurrencyProvider/reducer.ts
+++ b/app/src/providers/CurrencyProvider/reducer.ts
@@ -88,10 +88,7 @@ export const useCurrencyState = () => {
       }
       dispatch({ type: ActionTypes.SUCCESS, currency, exchangeRate })
     } catch (error: Error | any | unknown) {
-      Sentry.configureScope((scope) => {
-        scope.setTag('currency', currency)
-      })
-      Sentry.captureException(error)
+      Sentry.captureException(error, 'currency_conversion')
       const message =
         'Sorry, there was a problem changing your currency. You can continue shopping in USD and update your currency at checkout.'
       dispatch({ type: ActionTypes.ERROR, error, message })

--- a/app/src/providers/ErrorProvider/ErrorProvider.tsx
+++ b/app/src/providers/ErrorProvider/ErrorProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Sentry } from '../../services/sentry'
+import { Sentry, SentryEvent } from '../../services/sentry'
 import { useErrorReducer } from './reducer'
 import { parseError } from './parseError'
 
@@ -8,7 +8,11 @@ const { useEffect } = React
 interface ErrorContextValue {
   errorMessage: string | React.ReactNode | undefined
   isFatal?: boolean
-  handleError: (error: Error) => void
+  handleError: (
+    error: Error,
+    event: SentryEvent,
+    extra?: Record<string, any>,
+  ) => void
   clearError: () => void
 }
 
@@ -42,14 +46,17 @@ export const ErrorProvider = ({ children, error: parentError }: ErrorProps) => {
     } else {
       reset()
     }
-  }, [parentError])
+  }, [parentError, reset, setError])
 
-  const handleError = (error: Error, scope?: any) => {
+  const handleError = (
+    error: Error,
+    eventType: SentryEvent,
+    extra?: Record<string, any>,
+  ) => {
     const args = parseError(error)
 
     if (args.isFatal) {
-      if (scope) Sentry.configureScope(scope)
-      Sentry.captureException(error)
+      Sentry.captureException(error, eventType, extra)
     }
     setError(args)
   }

--- a/app/src/services/hubspot.ts
+++ b/app/src/services/hubspot.ts
@@ -72,9 +72,6 @@ export const submitToHubspot = async (
       throw response
     }
   } catch (err: any | unknown) {
-    Sentry.setContext('hubspotResponse', err)
-    Sentry.setContext('hubspotFormData', { body })
-    Sentry.configureScope((scope) => scope.setTag('integration', 'hubspot'))
-    Sentry.captureException(err)
+    Sentry.captureException(err, 'hubspot_error', { hubspotFormData: body })
   }
 }

--- a/app/src/services/mailchimp/mailchimp.ts
+++ b/app/src/services/mailchimp/mailchimp.ts
@@ -62,7 +62,7 @@ export const mailchimp: MailchimpService = {
         success: true,
       }
     } catch (error: any | unknown) {
-      Sentry.captureException(error)
+      Sentry.captureException(error, 'mailchimp_error', { input })
       return {
         success: false,
         error,

--- a/app/src/services/postmark/postmark.ts
+++ b/app/src/services/postmark/postmark.ts
@@ -81,7 +81,7 @@ const send = async (message: Message): Promise<PostmarkResponse> => {
       message,
     }
   } catch (error: any | unknown) {
-    Sentry.captureException(error)
+    Sentry.captureException(error, 'postmark_error')
     return {
       success: false,
       error,

--- a/app/src/services/sentry.ts
+++ b/app/src/services/sentry.ts
@@ -4,7 +4,6 @@ import type { Scope } from '@sentry/browser'
 import path from 'path'
 import { RewriteFrames } from '@sentry/integrations'
 import Debug from 'debug'
-import { Severity } from '@sentry/node'
 import { config } from '../config'
 
 /** Some Sentry setup for sourcemaps */
@@ -35,46 +34,86 @@ const SentryInitializer =
     ? NodeSentryInitializer
     : BrowserSentryInitializer
 
-export let Sentry: typeof SentryInitializer
-
-if (ENV === 'production' || ENV === 'staging' || FORCE) {
-  if (!SENTRY_DSN) throw new Error('No Sentry DSN supplied')
-  Sentry = SentryInitializer
-  Sentry.init({
-    dsn: SENTRY_DSN,
-    environment: ENV,
-    integrations: [
-      new RewriteFrames({
-        root: global.__rootdir__,
-      }),
-    ],
-  })
-} else {
-  debug('Mocking local sentry')
-  const noop = () => undefined
-  Sentry = {
-    // @ts-ignore
-    setUserContext: noop,
-    // @ts-ignore
-    requestHandler: () => (req, res, next) => next(),
-    parsers: {
-      parseRequest: noop,
-    },
-    setContext: (name: string, ctx: any) => {
-      debug('Set context:')
-      debug({ [name]: ctx })
-    },
-    configureScope: (callback: (scope: Scope) => void) => undefined,
-    captureException: (e: Error) => {
-      debug('Captured exception:')
-      debug(e)
-      const randomId = Math.random().toString().replace('0.', '')
-      return `mock-ref-${randomId}`
-    },
-    captureMessage: (m: string) => {
-      debug('Captured message:')
-      debug(m)
-      return m
-    },
+const getClient = () => {
+  if (ENV === 'production' || ENV === 'staging' || FORCE) {
+    if (!SENTRY_DSN) throw new Error('No Sentry DSN supplied')
+    SentryInitializer.init({
+      dsn: SENTRY_DSN,
+      environment: ENV,
+      integrations: [
+        new RewriteFrames({
+          root: global.__rootdir__,
+        }),
+      ],
+    })
+    return SentryInitializer
+  } else {
+    debug('Mocking local sentry')
+    const noop = () => undefined
+    /**
+     * A mocked client so we don't send errors in development
+     */
+    return {
+      // @ts-ignore
+      setUserContext: noop,
+      // @ts-ignore
+      requestHandler: () => (req, res, next) => next(),
+      parsers: {
+        parseRequest: noop,
+      },
+      setContext: (name: string, ctx: any) => {
+        debug('Set context:')
+        debug({ [name]: ctx })
+      },
+      configureScope: (callback: (scope: Scope) => void) => undefined,
+      captureException: (e: Error, context: any) => {
+        debug(`Captured exception: [${context?.tags?.event}]`)
+        debug(e, { context })
+        const randomId = Math.random().toString().replace('0.', '')
+        return `mock-ref-${randomId}`
+      },
+      captureMessage: (m: string) => {
+        debug('Captured message:')
+        debug(m)
+        return m
+      },
+    }
   }
+}
+
+const SentryClient = getClient()
+
+export type SentryEvent =
+  | 'sync_webhook_error'
+  | 'postmark_error'
+  | 'mailchimp_error'
+  | 'hubspot_error'
+  | 'currency_conversion'
+  | 'shopify_query_error'
+  | 'sanity_query_error'
+  | 'graphql_request_error'
+  | 'next_static_paths_error'
+  | 'next_static_props_error'
+  | 'sitemap_gen_error'
+  | 'algolia_index_error'
+  | 'algolia_parse_error'
+
+/**
+ * A wrapper for the base Sentry client that enforces
+ * the usage of tags, and makes passing additional information
+ * a little easier.
+ *
+ * Example usage:
+ *
+ * Sentry.captureException(someError, 'page_fetch_error', helpfulContext)
+ */
+export const Sentry = {
+  captureException: (
+    e: any,
+    event: SentryEvent,
+    extra?: Record<string, any>,
+  ) => {
+    console.error(e)
+    SentryClient.captureException(e, { tags: { event }, extra })
+  },
 }

--- a/app/src/services/webhooks.ts
+++ b/app/src/services/webhooks.ts
@@ -17,7 +17,7 @@ if (!shopName) throw new Error('You must provide a shopify shop name')
 if (!accessToken) throw new Error('You must provide a shopify access token')
 
 const handleError = (err: Error) => {
-  Sentry.captureException(err)
+  Sentry.captureException(err, 'sync_webhook_error')
 }
 
 const webhookConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -26643,6 +26643,7 @@ __metadata:
     text-mask-addons: ^3.8.0
     ts-jest: ^27.1.5
     ts-node: ^10.9.1
+    tsc-watch: ^6.0.0
     typescript: ^4.9.4
     typesync: ^0.9.2
     utf-8-validate: ^5.0.10
@@ -28175,6 +28176,22 @@ __metadata:
   bin:
     tsc-watch: index.js
   checksum: abd63295dd5fda098a45d27912031e6c35a95f1aa20d7a86d6ad1469580400069e6476f2ffd4b88e37886d016443e60b1ae2dbcaf756e324efc67d0fa713fb15
+  languageName: node
+  linkType: hard
+
+"tsc-watch@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "tsc-watch@npm:6.0.0"
+  dependencies:
+    cross-spawn: ^7.0.3
+    node-cleanup: ^2.1.2
+    ps-tree: ^1.2.0
+    string-argv: ^0.3.1
+  peerDependencies:
+    typescript: "*"
+  bin:
+    tsc-watch: dist/lib/tsc-watch.js
+  checksum: 34e74a703ecb28689d0f6ba311781ff68be47f5f095439654b095f3ea4a5921708fca61b5727e33527639a9a147b42d10bc3fe3595afee92b41b2bacfba06043
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This improves the sentry setup by:

- Enforcing that `Sentry.captureException` is used with a tag, and makes passing in contextual data easier
- Ignores hydration errors. I believe that the issue is because we're using an older version of @xstyled/styled-components; (see #236) since these errors aren't really having a large impact (other than on our Sentry usage), I added a `beforeSend` param to sentry that (I believe) will filter these errors out.