### PR TITLE
fix(app): adjust tablet layout of grid on .925 collection

### DIFF
--- a/app/src/components/Product/ProductGrid.tsx
+++ b/app/src/components/Product/ProductGrid.tsx
@@ -47,6 +47,7 @@ const ProductGridWrapper = styled.div<ProductGridWrapperProps>`
 
 interface WithFormat {
   format?: string | null
+  featured?: boolean | null
 }
 
 export const ProductGridItemPadding = styled.div<WithFormat>`
@@ -68,13 +69,17 @@ export const ProductGridItemPadding = styled.div<WithFormat>`
 `
 
 export const ProductGridItem = styled.div<WithFormat>`
-  ${({ theme, format }) => css`
+  ${({ theme, format, featured }) => css`
     grid-column: ${format === 'wide' ? 'span 2' : 'auto'};
     grid-row: ${format === 'tall' ? 'span 2' : 'auto'};
     position: relative;
 
     ${theme.mediaQueries.tablet} {
-      grid-column: ${format === 'wide' ? 'span 2' : 'auto'};
+      grid-column: ${format === 'wide' && featured
+        ? 'span 1'
+        : format === 'wide' && !featured
+        ? 'span 2'
+        : 'auto'};
       grid-row: ${format === 'tall' ? 'span 2' : 'auto'};
     }
     ${theme.mediaQueries.mobile} {
@@ -118,68 +123,8 @@ export const ProductGrid = ({
   reduceColumnCount,
   collectionId,
 }: ProductGridProps) => {
-  // const { y } = useWindowScroll()
-
-  // const pageRef = React.useRef(null)
-  // const [height, setHeight] = React.useState(0)
-  // const router = useRouter()
-
-  // const updateQueryParam = (query) => {
-  //   router.replace(
-  //     {
-  //       query: query,
-  //     },
-  //     '',
-  //     { shallow: true },
-  //   )
-  // }
-
-  // // React.useEffect(() => {
-  // //   if (!router.isReady) return
-  // //   console.log('currentFilter', currentFilter)
-  // //   setHeight(pageRef.current.getBoundingClientRect().height)
-  // // }, [currentFilter])
-
-  // console.log('height', height)
-
-  // React.useEffect(() => {
-  //   if (!router.isReady) return
-  //   console.log('calcued', height * parseFloat(router.query.pos as string))
-
-  //   if (router.query.pos) {
-  //     window.scrollTo({
-  //       top: height * parseFloat(router.query.pos as string),
-  //       behavior: 'smooth',
-  //     })
-  //   }
-  // }, [currentFilter])
-
-  // console.log(router.query.pos)
-
-  // useDebounce(
-  //   () => {
-  //     if (!router.isReady) return
-
-  //     setHeight(pageRef.current.getBoundingClientRect().height)
-
-  //     const min = 0
-  //     const max = 1
-
-  //     const clamp = (num, min, max) => Math.min(Math.max(num, min), max)
-
-  //     const yPos = clamp(y / height, min, max)
-
-  //     if (yPos !== 0) {
-  //       updateQueryParam({ ...router.query, pos: yPos.toFixed(3) })
-  //     } else {
-  //       const { pos, ...removeFromQuery } = router.query
-
-  //       updateQueryParam({ ...removeFromQuery })
-  //     }
-  //   },
-  //   250,
-  //   [y],
-  // )
+  const router = useRouter()
+  const featuredLayout = router.query.collectionSlug === '925-collection'
 
   return (
     <ProductGridWrapper reduceColumnCount={reduceColumnCount}>
@@ -189,6 +134,7 @@ export const ProductGrid = ({
             return (
               <ProductGridItem
                 format={item.format}
+                featured={featuredLayout}
                 key={item._key || 'some-key'}
               >
                 <ProductGridItemPadding format={item.format} />


### PR DESCRIPTION
**Tablet product carousel should crop double-wide blocks to square on Tablet Screen size (.925 Collection)**
https://www.notion.so/goodidea/Tablet-product-carousel-should-crop-double-wide-blocks-to-square-on-Tablet-Screen-size-925-Collect-0b723c83d8d846a58b3863705128d2df?pvs=4

- adds `featured` prop to `ProductGridItem`..., which adjusts the grid layout on tablet to keep the product and accompanying collection block on the same line. Since (I think) the only collection this currently is needed is on the .925 collection, it is being set only if `router.query.collectionSlug === '925-collection'`. If we end up using this format on other collections, it would be preferable to add it as an option in sanity. 
- removes commented out code