### PR TITLE
fix(app): GA4 Analytics Improvements

### DIFF
--- a/app/src/providers/AnalyticsProvider/AnalyticsProvider.tsx
+++ b/app/src/providers/AnalyticsProvider/AnalyticsProvider.tsx
@@ -10,6 +10,8 @@ import {
 } from '../../utils'
 import { parseProduct } from './utils'
 import { SelectedProduct, EventType, GTagEvent } from './types'
+import { ConvertSizeLocaleField } from '../../components/Forms/CustomFields/ConvertSizeLocaleField'
+import { ShopifyStorefrontCurrencyCode } from '../../types/generated-shopify'
 
 const { useEffect } = React
 
@@ -144,9 +146,16 @@ export const AnalyticsProvider = ({ children }: AnalyticsProps) => {
     const products = arrayify(selected).map((s, i) =>
       parseProduct(s, { position: i + 1 }),
     )
+
     sendEvent({
       event: EventType.RemoveFromCart,
-      ecommerce: { remove: { products } },
+      ecommerce: {
+        remove: {
+          currency: ShopifyStorefrontCurrencyCode.Usd,
+          value: 7.77,
+          products,
+        },
+      },
     })
   }
   const sendBeginCheckout: AnalyticsContextValue['sendBeginCheckout'] = (

--- a/app/src/providers/AnalyticsProvider/types.ts
+++ b/app/src/providers/AnalyticsProvider/types.ts
@@ -2,6 +2,7 @@ import {
   ShopifyStorefrontProductVariant as Variant,
   ShopifyStorefrontProduct as Product,
   ShopifyStorefrontCheckoutLineItem as CheckoutLineItem,
+  ShopifyStorefrontCurrencyCode,
 } from '../../types/generated-shopify'
 import {
   ShopifyProduct,
@@ -93,6 +94,8 @@ interface RemoveFromCartEvent {
   event: EventType.RemoveFromCart
   ecommerce: {
     remove: {
+      currency: ShopifyStorefrontCurrencyCode
+      value: number
       products: EcommerceObject[]
     }
   }


### PR DESCRIPTION
- Modify GA4 for extra returning customer data
- Monetization: Fix the view for Total Purchasers vs First time purchasers
- Filter Order Type: exclude draft orders?
- Explore Creating unique IDs for customers? Cross ref shopify and GA4 assign unique IDs
- Adding Variant Info to conversions