### PR TITLE
feat(app): add strike-through pricing to cart

### DIFF
--- a/app/src/components/Cart/CheckoutProduct.tsx
+++ b/app/src/components/Cart/CheckoutProduct.tsx
@@ -216,14 +216,6 @@ export const CheckoutProduct = ({ lineItem }: CheckoutLineItemProps) => {
               </Span>
             )}
           </Heading>
-          {/* <Heading level={4} weight={1} mb={0} mt={{ xs: 1, md: 2 }}>
-            <Price price={priceV2} />
-            {compareAtPriceV2 && (
-              <Span ml={2} color="body.6" textDecoration="line-through">
-                <Price price={compareAtPriceV2} />
-              </Span>
-            )}
-          </Heading> */}
           {displayOptions(variant).map((o, i) => {
             return (
               <Heading level={5} weight={2} mb={0} mt={0} key={i}>

--- a/app/src/components/Cart/CheckoutProduct.tsx
+++ b/app/src/components/Cart/CheckoutProduct.tsx
@@ -3,7 +3,7 @@ import { Box } from '@xstyled/styled-components'
 import Link from 'next/link'
 import { useShopify, useAnalytics } from '../../providers'
 import { ShopifyStorefrontCheckoutLineItem as CheckoutLineItemType } from '../../types/generated-shopify'
-import { Heading } from '../../components/Text'
+import { Heading, Span } from '../../components/Text'
 import { Image } from '../../components/Image'
 import TrashIcon from '../../svg/TrashCan.svg'
 import { Button } from '../../components/Button'
@@ -210,7 +210,20 @@ export const CheckoutProduct = ({ lineItem }: CheckoutLineItemProps) => {
           </Link>
           <Heading level={5} weight={2} mb={0} mt={0} textTransform="uppercase">
             <Price price={variant.priceV2} />
+            {variant.compareAtPriceV2 && (
+              <Span ml={2} color="body.6" textDecoration="line-through">
+                <Price price={variant.compareAtPriceV2} />
+              </Span>
+            )}
           </Heading>
+          {/* <Heading level={4} weight={1} mb={0} mt={{ xs: 1, md: 2 }}>
+            <Price price={priceV2} />
+            {compareAtPriceV2 && (
+              <Span ml={2} color="body.6" textDecoration="line-through">
+                <Price price={compareAtPriceV2} />
+              </Span>
+            )}
+          </Heading> */}
           {displayOptions(variant).map((o, i) => {
             return (
               <Heading level={5} weight={2} mb={0} mt={0} key={i}>

--- a/app/src/views/ProductDetail/components/ProductDetailHeader.tsx
+++ b/app/src/views/ProductDetail/components/ProductDetailHeader.tsx
@@ -134,9 +134,11 @@ export const ProductDetailHeader = ({
         {inquiryOnly !== true ? (
           <Heading level={4} weight={1} mb={0} mt={{ xs: 1, md: 2 }}>
             <Price price={priceV2} />
-            <Span ml={2} color="body.6" textDecoration="line-through">
-              <Price price={compareAtPriceV2} />
-            </Span>
+            {compareAtPriceV2 && (
+              <Span ml={2} color="body.6" textDecoration="line-through">
+                <Price price={compareAtPriceV2} />
+              </Span>
+            )}
           </Heading>
         ) : null}
       </TitleWrapper>


### PR DESCRIPTION
**Strikethrough pricing in cart**
https://www.notion.so/goodidea/Strikethrough-pricing-in-cart-ad10f7341c304c65be0c384c6c11b8b3?pvs=4

- inside checkout, add strikethrough pricing for all products that have a `compareAtPriceV2` value
- test at: https://spinellikilcollin-git-feat-strike-thr-79dbf3-spinelli-kilcollin.vercel.app/collections/giaf