### PR TITLE
feat(app): disable BuyButton until availableForSale is known

### DIFF
--- a/app/src/providers/AllProviders.tsx
+++ b/app/src/providers/AllProviders.tsx
@@ -38,7 +38,7 @@ const deduplicateFragments = (queryString?: string) =>
         .join('\n\n')
     : ''
 
-async function shopifyQuery<Response>(
+export async function shopifyQuery<Response>(
   query: string | DocumentNode,
   variables?: Record<string, unknown>,
 ): Promise<Response> {


### PR DESCRIPTION
Adds a hook to query the Storefront API directly when rendering the Buy Button to ensure that the selected variant is in stock