### PR TITLE
chore(app): catch product/collection update sync timeouts

### DIFF
--- a/app/pages/api/onCollectionUpdate.ts
+++ b/app/pages/api/onCollectionUpdate.ts
@@ -1,3 +1,24 @@
-import { webhooks } from '../../src/services/webhooks'
+import { NextApiHandler } from 'next'
 
-export default webhooks.onCollectionUpdate
+import { webhooks } from '../../src/services/webhooks'
+import { Sentry } from '../../src/services/sentry'
+
+const handler: NextApiHandler = async (req, res) => {
+  try {
+    console.log(`onCollectionUpdate: ${req.body.id}`)
+    const timeout = setTimeout(() => {
+      throw new Error('Timeout: onCollectionUpdate')
+    }, 55000)
+    await webhooks.onProductUpdate(req, res)
+    clearTimeout(timeout)
+  } catch (e) {
+    const error =
+      e instanceof Error ? e : new Error('An unknown syncing error occurred')
+    Sentry.captureException(error, 'sync_webhook_error', {
+      body: req.body,
+    })
+    res.status(500).json({ message: error.message })
+  }
+}
+
+export default handler


### PR DESCRIPTION
It turns out that the syncs are occasionally timing out - running for longer than 60 seconds. These weren't being caught by Sentry because vercel is just shutting down the function, nothing is being thrown (and then caught) by Sentry.

It appears that some products take a long time to sync. I'm not sure why, but the logs don't even include the product ID. This PR adds some additional logging info, and forces our own timeout (at 55 seconds) that we can catch & report to sentry.



