### PR TITLE
feat(sanity): add xl font size to hero heading

### DIFF
--- a/app/src/components/ContentBlock/HeroBlock.tsx
+++ b/app/src/components/ContentBlock/HeroBlock.tsx
@@ -122,7 +122,7 @@ const HeroText = styled.div`
     .text-container {
       ${
         textXL
-          ? 'max-width: none;'
+          ? 'max-width: 90vw;'
           : textContainer == 'full'
           ? 'max-width: 720px;'
           : textContainer == 'half-left' || textContainer == 'half-right'
@@ -189,11 +189,6 @@ const HeroText = styled.div`
       }
     }
 
-    ${
-      textXL &&
-      `h1 {
-      font-size: 100px;
-    }`
     }
     h1 {
       font-size: ${

--- a/app/src/components/ContentBlock/HeroBlock.tsx
+++ b/app/src/components/ContentBlock/HeroBlock.tsx
@@ -78,6 +78,7 @@ interface HeroTextProps {
   textPositionMobile?: string | null
   textColorMobile?: string | null
   textContainer?: string | null
+  textXL?: boolean | null
 }
 
 const HeroText = styled.div`
@@ -88,6 +89,7 @@ const HeroText = styled.div`
     textPosition,
     textColor,
     textPositionMobile,
+    textXL,
     textColorMobile,
     textContainer,
   }: HeroTextProps) => css`
@@ -119,12 +121,15 @@ const HeroText = styled.div`
 
     .text-container {
       ${
-        textContainer == 'full'
+        textXL
+          ? 'max-width: none;'
+          : textContainer == 'full'
           ? 'max-width: 720px;'
           : textContainer == 'half-left' || textContainer == 'half-right'
           ? 'max-width: 60%;'
           : 'max-width: 400px'
       };
+
 
       ${
         textContainer == 'half-top' || textContainer == 'half-bottom'
@@ -184,6 +189,18 @@ const HeroText = styled.div`
       }
     }
 
+    ${
+      textXL &&
+      `h1 {
+      font-size: 100px;
+    }`
+    }
+    h1 {
+      font-size: ${
+        textContainer == 'full' && textXL ? '14vw' : theme.fontSizes[1]
+      };
+
+    }
     ${theme.mediaQueries.tablet} {
       ${
         minimalDisplay
@@ -194,7 +211,7 @@ const HeroText = styled.div`
       ${
         textContainer == 'full'
           ? `h1 {
-              font-size: ${theme.mobileFontSizes[1]};
+              font-size: ${textXL ? '14vw' : theme.mobileFontSizes[1]};
             }
             h2 {
               font-size: ${theme.mobileFontSizes[2]};
@@ -310,6 +327,7 @@ export const HeroBlock = React.forwardRef(
       textPosition,
       textColor,
       textContainer,
+      textXL,
       heroLink,
       bodyRaw,
       body_mobileRaw,
@@ -344,6 +362,8 @@ export const HeroBlock = React.forwardRef(
       }
     }, [])
 
+    console.log('textXL', textXL)
+
     return (
       <HeroWrapper hero={hero} ref={ref} minimalDisplay={minimalDisplay}>
         <DocumentLink document={heroLink?.document ?? undefined}>
@@ -362,6 +382,7 @@ export const HeroBlock = React.forwardRef(
           )}
           <HeroText
             textPosition={textPosition}
+            textXL={textXL}
             textColor={textColor}
             textPositionMobile={textPositionMobile}
             textColorMobile={textColorMobile}

--- a/app/src/graphql/fragments/content.ts
+++ b/app/src/graphql/fragments/content.ts
@@ -689,6 +689,7 @@ export const heroFragment = gql`
     textColorMobileCustom {
       ...ColorFragment
     }
+    textXL
     textContainer
     textPosition
     textPositionMobile

--- a/app/src/types/generated-sanity.ts
+++ b/app/src/types/generated-sanity.ts
@@ -1043,6 +1043,8 @@ export interface Hero {
   layout?: Maybe<Scalars['String']>
   /** Limit the size of the text container. (Default: Full Width) */
   textContainer?: Maybe<Scalars['String']>
+  /** Extra-large heading text size for banners (for use with H1) */
+  textXL?: Maybe<Scalars['Boolean']>
   textPosition?: Maybe<Scalars['String']>
   textPositionMobile?: Maybe<Scalars['String']>
   textColor?: Maybe<Scalars['String']>
@@ -1067,6 +1069,7 @@ export type HeroFilter = {
   header_color?: Maybe<StringFilter>
   layout?: Maybe<StringFilter>
   textContainer?: Maybe<StringFilter>
+  textXL?: Maybe<BooleanFilter>
   textPosition?: Maybe<StringFilter>
   textPositionMobile?: Maybe<StringFilter>
   textColor?: Maybe<StringFilter>
@@ -1091,6 +1094,7 @@ export type HeroSorting = {
   header_color?: Maybe<SortOrder>
   layout?: Maybe<SortOrder>
   textContainer?: Maybe<SortOrder>
+  textXL?: Maybe<SortOrder>
   textPosition?: Maybe<SortOrder>
   textPositionMobile?: Maybe<SortOrder>
   textColor?: Maybe<SortOrder>

--- a/sanity/schemas/objects/hero.js
+++ b/sanity/schemas/objects/hero.js
@@ -120,6 +120,13 @@ export const hero = {
       },
     },
     {
+      name: 'textXL',
+      label: 'Text Oversized',
+      type: 'boolean',
+      description:
+        'Extra-large heading text size for banners (for use with H1)',
+    },
+    {
       name: 'textPosition',
       title: 'Text Position',
       type: 'position',


### PR DESCRIPTION
In sanity, adds an option to turn on an extra-large font-size for hero heading text. This will be added to the hero panel on sanity, and is only enabled for H1 styled text. The font-size is dynamic, so it will resize with the page width. 

test link: https://spinellikilcollin-7m1m4efps-spinelli-kilcollin.vercel.app/about/test-julian

---

<img width="825" alt="image" src="https://github.com/beelaineo/spinellikilcollin.com/assets/6518748/367f9425-ef1e-4e0c-b1cc-f2af8aa4f367">
