### PR TITLE
fix(app): adjust affirm overlap

### DIFF
--- a/app/src/components/Affirm.tsx
+++ b/app/src/components/Affirm.tsx
@@ -41,7 +41,7 @@ export const Affirm = ({ price }: AffirmProps) => {
   return (
     <Heading level={5} weight={2} my={0}>
       <span
-        style={{ display: 'block', height: '20px' }} //fixed height to prevent jumping
+        style={{ display: 'block', minHeight: '20px' }} //fixed min-height to prevent jumping
         className="affirm-as-low-as"
         data-amount={cents}
         data-affirm-color="black"

--- a/app/src/views/ProductDetail/styled.tsx
+++ b/app/src/views/ProductDetail/styled.tsx
@@ -82,6 +82,12 @@ export const AffirmWrapper = styled.div`
     display: flex;
     flex-direction: column;
     gap: 2;
+    width: max-content;
+    h5,
+    span {
+      height: 100%;
+      text-align: left;
+    }
 
     ${theme.mediaQueries.tablet} {
       grid-row: 3;
@@ -89,6 +95,9 @@ export const AffirmWrapper = styled.div`
       width: 100%;
       max-width: small;
       align-items: center;
+    }
+    ${theme.mediaQueries.mobile} {
+      align-items: flex-start;
     }
     a {
       position: relative;
@@ -102,6 +111,7 @@ export const AffirmWrapper = styled.div`
 export const KlarnaWrapper = styled.div`
   ${({ theme }) => css`
     margin-top: 5;
+
     ${theme.mediaQueries.tablet} {
       grid-row: 3;
       margin: 4 auto 0;


### PR DESCRIPTION
- changes fixed span `height` to a fixed `min-height`
- changes width on desktop to `max-content` to prevent line-break
- aligns affirm content to left on mobile