### PR TITLE
fix(app): add hideFromSearch filter

### DIFF
--- a/app/src/components/Search/SearchInput.tsx
+++ b/app/src/components/Search/SearchInput.tsx
@@ -157,6 +157,9 @@ export const SearchInput = () => {
                         query,
                         params: {
                           hitsPerPage: 4,
+                          typoTolerance: 'min',
+                          exactOnSingleWordQuery: 'word',
+                          filters: `hideFromSearch:false`,
                         },
                       },
                     ],

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "functions": {
-    "api/algoliaIndex": {
+    "api/algoliaIndex.ts": {
       "maxDuration": 90
     }
   }

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "functions": {
-    "api/algoliaIndex.ts": {
+    "src/pages/api/algoliaIndex.ts": {
       "maxDuration": 90
     }
   }

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,3 +1,8 @@
 {
-  "version": 2
+  "version": 2,
+  "functions": {
+    "api/algoliaIndex": {
+      "maxDuration": 90
+    }
+  }
 }

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "functions": {
-    "src/pages/api/algoliaIndex.ts": {
+    "pages/api/algoliaIndex.ts": {
       "maxDuration": 90
     }
   }


### PR DESCRIPTION
- adds missing search params including `hideFromSearch:false` to query suggestion interface
- fixes algolia index refresh link by increasing server function timeout limit: https://vercel.com/docs/functions/configuring-functions/duration

---

test refresh link at: https://spinellikilcollin-git-fix-algolia-hid-b322d1-spinelli-kilcollin.vercel.app/api/algoliaIndex