### PR TITLE
feat(app): update gift card range slider

### DIFF
--- a/app/src/components/Forms/Fields/ProductPriceInput.tsx
+++ b/app/src/components/Forms/Fields/ProductPriceInput.tsx
@@ -43,25 +43,6 @@ export const ProductPriceInput = (props: ProductPriceInputProps) => {
     onChange,
   } = props
 
-  const optionsNumeric =
-    options !== undefined
-      ? options.map((option: Option) => {
-          return Number(option.label.toString().replace(/[^0-9\.-]+/g, ''))
-        })
-      : []
-
-  const conformValue = (conformedValue: string) => {
-    const numericValue = Number(conformedValue.replace(/[^0-9\.-]+/g, ''))
-
-    const closest = optionsNumeric.reduce(function (prev, curr) {
-      return Math.abs(curr - numericValue) < Math.abs(prev - numericValue)
-        ? curr
-        : prev
-    })
-    const remasked = conformToMask(closest.toString(), currencyMask)
-    return remasked.conformedValue
-  }
-
   return (
     <FieldWrapper>
       <FormikField validate={validate} name={name}>
@@ -72,7 +53,7 @@ export const ProductPriceInput = (props: ProductPriceInputProps) => {
             </Span>
             <InputRangeElement
               {...field}
-              value={field.value || '50'}
+              value={field.value || '0'}
               id={field.name}
               onChange={field.onChange}
               onInput={onChange}
@@ -80,9 +61,9 @@ export const ProductPriceInput = (props: ProductPriceInputProps) => {
               placeholder={placeholder}
               color={color}
               type={'range'}
-              min={50}
-              max={5000}
-              step={50}
+              min={0}
+              max={options ? options.length - 1 : 10000}
+              step={1}
             />
           </>
         )}

--- a/app/src/components/Forms/Form.tsx
+++ b/app/src/components/Forms/Form.tsx
@@ -29,6 +29,7 @@ interface FormProps<Values> {
   initialValues: Values
   children: React.ReactNode
   validationSchema?: FormikValues['validationSchema']
+  enableReinitialize?: boolean
 }
 
 export function Form<Values extends FormikValues>({
@@ -41,6 +42,7 @@ export function Form<Values extends FormikValues>({
   initialValues,
   children,
   validationSchema,
+  enableReinitialize = false,
 }: FormProps<Values>) {
   return (
     <FormWrapper disabled={disabled}>
@@ -64,6 +66,7 @@ export function Form<Values extends FormikValues>({
           actions.setSubmitting(false)
         }}
         validationSchema={validationSchema}
+        enableReinitialize={enableReinitialize}
       >
         {({ handleSubmit, values, isSubmitting }) => {
           React.useEffect(() => {

--- a/app/src/views/ProductDetail/components/ProductOptionSelector.tsx
+++ b/app/src/views/ProductDetail/components/ProductOptionSelector.tsx
@@ -226,13 +226,12 @@ export const ProductOptionSelector = ({
       : []
 
   const handleProductInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const inputValue: number = Number(e.target.value) || 50
-    const closest = optionsNumeric.reduce(function (prev, curr) {
-      return Math.abs(curr - inputValue) < Math.abs(prev - inputValue)
-        ? curr
-        : prev
-    })
-    const remasked = conformToMask(closest.toString(), currencyMask)
+    const inputValue: number = Number(e.target.value) || 0
+
+    const scaledValue = optionsNumeric[inputValue]
+
+    const remasked = conformToMask(scaledValue.toString(), currencyMask)
+
     selectOption(remasked.conformedValue)
   }
 
@@ -259,6 +258,17 @@ export const ProductOptionSelector = ({
   const handleSubmit = (values: any) => {
     //
   }
+
+  useEffect(() => {
+    if (isInput && option.name) {
+      const value = currentVariant?.sourceData?.priceV2?.amount
+      if (value) {
+        const scaledValue = optionsNumeric.indexOf(value)
+        setInitialValue(scaledValue)
+      }
+    }
+  }, [])
+
   return (
     <Wrapper>
       <Heading level={5} mb={2}>

--- a/app/src/views/ProductDetail/components/ProductOptionSelector.tsx
+++ b/app/src/views/ProductDetail/components/ProductOptionSelector.tsx
@@ -85,14 +85,15 @@ export const ProductOptionSelector = ({
   currentVariant,
   isInput,
 }: ProductOptionSelectorProps) => {
+  const [activeStone, setActiveStone] = useState<Maybe<Stone> | undefined>(null)
+  const [initialValue, setInitialValue] = useState(0)
+
   if (!option || !option.name || !option.values) {
     console.warn('Missing option config', option)
     return null
   }
 
   if (option.values.length === 0) return null
-
-  const [activeStone, setActiveStone] = useState<Maybe<Stone> | undefined>(null)
 
   const selectOption = changeValueForOption(option.name)
 
@@ -285,7 +286,11 @@ export const ProductOptionSelector = ({
             />
           </SwatchesWrapper>
         ) : (
-          <Form onSubmit={handleSubmit} initialValues={{}}>
+          <Form
+            onSubmit={handleSubmit}
+            initialValues={{ Value: initialValue }}
+            enableReinitialize={true}
+          >
             {isInput ? (
               <ProductPriceInput
                 name={option.name}

--- a/app/src/views/ProductDetail/components/ProductVariantSelector.tsx
+++ b/app/src/views/ProductDetail/components/ProductVariantSelector.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import styled from '@xstyled/styled-components'
-import { Box } from '@xstyled/styled-components'
+import styled, { Box } from '@xstyled/styled-components'
 import { Product, ShopifyProductVariant } from '../../../types'
 import { ProductOptionSelector } from './ProductOptionSelector'
 import { getValidProductOptions, optionMatchesVariant } from '../../../utils'


### PR DESCRIPTION
- `ProductPriceInput` range slider values are populated variants, rather than equal steps. 
- On initial load, range slider initial position now matches variant value from query param. 
- Add `enableReinitialize` as prop to Form component (allows initial values to be reset)

test link: https://spinellikilcollin-git-feat-update-gif-5b6bec-spinelli-kilcollin.vercel.app/products/gift-card
test link with variant in url: https://spinellikilcollin-git-feat-update-gif-5b6bec-spinelli-kilcollin.vercel.app/products/gift-card?v=Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTQ4MjExNjE0NTI1MA%3D%3D