### PR TITLE
feat(app): reduce breadcrumb queries

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -2,15 +2,15 @@ import * as React from 'react'
 import { NextRouter } from 'next/router'
 import styled, { ThemeProvider } from '@xstyled/styled-components'
 import Head from 'next/head'
-import Script from 'next/script'
 import { Providers } from '../src/providers/AllProviders'
 import { Footer } from '../src/components/Footer'
 import { Navigation } from '../src/components/Navigation'
 import { SearchPane } from '../src/components/Search'
 import { ToastRoot } from '../src/components/Toast'
 import { getThemeByRoute } from '../src/theme'
-import { config } from '../src/config'
 import { KeepAliveProvider } from 'react-next-keep-alive'
+import { Breadcrumbs } from '../src/components/Footer/Breadcrumbs'
+import { useBreadcrumbs } from '../src/hooks/useBreadcrumbs'
 
 import '../public/static/fonts/fonts.css'
 
@@ -31,7 +31,6 @@ const App = (props: AppProps) => {
   const { Component, pageProps: allPageProps, router } = props
   const path = router.asPath
   const { shopData, ...pageProps } = allPageProps
-  if (!shopData) return null
 
   // Hubspot Conversations launcher
   useEffect(() => {
@@ -64,6 +63,9 @@ const App = (props: AppProps) => {
     storage.setItem('currentPath', globalThis.location.pathname)
   }
 
+  const breadCrumbs = useBreadcrumbs()
+
+  if (!shopData) return null
   return (
     <Providers shopData={shopData}>
       <ThemeProvider theme={getThemeByRoute(path)}>
@@ -74,14 +76,14 @@ const App = (props: AppProps) => {
           />
         </Head>
         <Main>
-          <Navigation />
-          <SearchPane />
+          <Navigation breadCrumbs={breadCrumbs} />
+          <SearchPane breadCrumbs={breadCrumbs} />
           <ToastRoot />
           <KeepAliveProvider router={router}>
             <Component {...pageProps} />
           </KeepAliveProvider>
 
-          <Footer />
+          <Footer breadCrumbs={breadCrumbs} />
         </Main>
         <div id="modal" />
       </ThemeProvider>

--- a/app/src/components/Footer/Breadcrumbs.tsx
+++ b/app/src/components/Footer/Breadcrumbs.tsx
@@ -1,82 +1,12 @@
 import * as React from 'react'
-import gql from 'graphql-tag'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { Product, Collection, Page, JournalEntry } from '../../types'
-import { request } from '../../../src/graphql'
 
 import { BreadcrumbWrapper } from './styled'
 
-const { useState, useEffect } = React
-
-const productQuery = gql`
-  query ProductsPageQuery($handle: String) {
-    allProduct(where: { handle: { eq: $handle }, archived: { neq: true } }) {
-      __typename
-      _id
-      _key
-      shopifyId
-      title
-      handle
-      collections {
-        __typename
-        _id
-        _key
-        title
-        handle
-        shopifyId
-      }
-    }
-  }
-`
-const collectionQuery = gql`
-  query CollectionQuery($handle: String) {
-    allCollection(where: { handle: { eq: $handle }, archived: { neq: true } }) {
-      __typename
-      _id
-      _type
-      _key
-      title
-      handle
-      archived
-      shopifyId
-    }
-  }
-`
-const pageQuery = gql`
-  query PageQuery($slug: String!) {
-    allPage(where: { slug: { current: { eq: $slug } } }) {
-      __typename
-      title
-      subtitle
-      slug {
-        current
-      }
-    }
-  }
-`
-const journalEntryQuery = gql`
-  query JournalEntryQuery($slug: String) {
-    allJournalEntry(where: { slug: { current: { eq: $slug } } }) {
-      _id
-      _type
-      title
-      subtitle
-      slug {
-        current
-      }
-    }
-  }
-`
-
-interface Response {
-  allProduct: Product[]
-  allCollection: Collection[]
-  allPage: Page[]
-  allJournalEntry: JournalEntry[]
-}
 interface BreadcrumbsProps {
   display?: string
+  paths?: []
 }
 
 interface BreadcrumbProps {
@@ -85,167 +15,8 @@ interface BreadcrumbProps {
   link: string
 }
 
-const Route2LabelMap = {
-  '/': 'Home',
-  '/404': 'Page Not Found',
-  '/about': 'About',
-  '/about/contact': 'Contact',
-  '/about/faq': 'FAQ',
-  '/about/appointments': 'Appointments',
-  '/about/team': 'Team',
-  '/blogs': 'Blog',
-  '/collections': 'Collections',
-  '/customize': 'Customize',
-  '/journal': 'Journal',
-  '/pages': 'Pages',
-  '/pages/[slug]': 'Page Not Found',
-  '/products': 'Collection',
-  '/customize/quiz': 'Quiz',
-  '/about/financing': 'Financing',
-}
-
-export const Breadcrumbs = ({ display }: BreadcrumbsProps) => {
+export const Breadcrumbs = ({ display, paths }: BreadcrumbsProps) => {
   const router = useRouter()
-  const [crumbs, setCrumbs] = useState([])
-  const storage = globalThis?.sessionStorage
-  const getProduct = async () => {
-    const handle = router?.query.productSlug
-    const variables = { handle }
-    const [response] = await Promise.all([
-      request<Response>(productQuery, variables),
-    ])
-    const products = response?.allProduct
-    const product = products && products.length ? products[0] : null
-    return product
-  }
-  const getCollection = async (handle) => {
-    const variables = { handle }
-    const [response] = await Promise.all([
-      request<Response>(collectionQuery, variables),
-    ])
-    const collections = response?.allCollection
-    const collection = collections && collections.length ? collections[0] : null
-    return collection
-  }
-  const getPage = async (slug) => {
-    const variables = { slug }
-    const [response] = await Promise.all([
-      request<Response>(pageQuery, variables),
-    ])
-    const pages = response?.allPage
-    const page = pages && pages.length ? pages[0] : null
-    return page
-  }
-  const getJournalEntry = async (slug) => {
-    const variables = { slug }
-    const [response] = await Promise.all([
-      request<Response>(journalEntryQuery, variables),
-    ])
-    const entries = response?.allJournalEntry
-    const entry = entries && entries.length ? entries[0] : null
-    return entry
-  }
-
-  useEffect(() => {
-    const segmentsPath = router.asPath.split('/')
-    const segmentsRoute = router.route.split('/')
-    const crumbLinks = CombineAccumulatively(segmentsPath)
-    const crumbLabels = CombineAccumulatively(segmentsRoute)
-
-    // console.log('segmentsPath', segmentsPath)
-    // console.log('crumbLinks', crumbLinks)
-    // console.log('segmentsRoute', segmentsRoute)
-    // console.log('crumbLabels', crumbLabels)
-
-    const fetchCrumbs = async () => {
-      switch (segmentsRoute[1]) {
-        case 'products':
-          const product = await getProduct()
-          if (
-            typeof storage.prevPath !== 'undefined' &&
-            storage.prevPath.split('/')[1] == 'collections'
-          ) {
-            const segmentsPrevPath = storage.prevPath.split('/')
-            const productCollection = await getCollection(segmentsPrevPath[2])
-            const collectionLink =
-              `/collections/${segmentsPrevPath[2]}` ||
-              '/collections/newarrivals'
-            const collectionLabel = productCollection?.title || 'Collection'
-            crumbLinks.splice(1, 1, collectionLink)
-            crumbLabels.splice(1, 1, collectionLabel)
-          } else {
-            const collection =
-              product?.collections && product?.collections.length
-                ? product.collections[0]
-                : null
-            const collectionLink =
-              collection !== null
-                ? `/collections/${collection.handle}`
-                : '/collections/newarrivals'
-            const collectionLabel =
-              collection !== null ? collection.title : 'Collection'
-            crumbLinks.splice(1, 1, collectionLink)
-            crumbLabels.splice(1, 1, collectionLabel)
-          }
-          crumbLabels[2] = product?.title || 'Product'
-          break
-        case 'collections':
-          const handle = router.query?.collectionSlug
-          const collection = handle ? await getCollection(handle) : null
-          crumbLinks.splice(1, 1)
-          crumbLabels.splice(1, 1)
-          crumbLabels[1] = collection?.title
-          break
-        case 'about':
-          if (segmentsPath[2] === 'financing') {
-            crumbLabels[2] = 'Financing'
-          } else if (
-            segmentsPath[2] === 'issues-we-care-about' ||
-            segmentsPath[2] === 'product-sourcing'
-          ) {
-            crumbLinks.splice(1, 1, '/about/our-values')
-            crumbLabels.splice(1, 1, 'Our Values')
-            const page = await getPage(router.query?.pageSlug)
-            crumbLabels[2] = page?.title
-          } else {
-            if (
-              segmentsRoute.length > 2 &&
-              segmentsRoute[2] !== 'contact' &&
-              segmentsRoute[2] !== 'faq' &&
-              segmentsRoute[2] !== 'appointments' &&
-              segmentsRoute[2] !== 'team'
-            ) {
-              const page = await getPage(router.query?.pageSlug)
-              crumbLabels[2] = page?.title
-            }
-          }
-          break
-        case 'journal':
-          if (segmentsRoute.length > 2) {
-            const journal = await getJournalEntry(router.query?.entrySlug)
-            crumbLabels[2] = journal?.title
-          }
-          break
-        case '':
-          crumbLinks.splice(1, 1)
-          crumbLabels.splice(1, 1)
-          break
-        default:
-      }
-
-      const crumbs = crumbLinks.map((link, index) => {
-        const route = crumbLabels[index]
-        const crumb = {
-          link: link,
-          route: route,
-          label: Route2LabelMap[route] || route,
-        }
-        return crumb
-      })
-      setCrumbs(crumbs)
-    }
-    fetchCrumbs()
-  }, [router.asPath])
 
   if (
     router.route === '/' ||
@@ -259,11 +30,11 @@ export const Breadcrumbs = ({ display }: BreadcrumbsProps) => {
   } else {
     return (
       <BreadcrumbWrapper>
-        {crumbs.map((c: BreadcrumbProps, i: number) => {
+        {paths?.map((c: BreadcrumbProps, i: number) => {
           return (
             <div key={i}>
               {i > 0 ? <div className={'separator'}>{'→'}</div> : null}
-              <div className={i == crumbs.length - 1 ? 'active ' : ''}>
+              <div className={i == paths.length - 1 ? 'active ' : ''}>
                 <Link href={c.link}>{c.label}</Link>
               </div>
             </div>
@@ -273,14 +44,4 @@ export const Breadcrumbs = ({ display }: BreadcrumbsProps) => {
       </BreadcrumbWrapper>
     )
   }
-}
-
-function CombineAccumulatively(segments) {
-  const links = segments.reduce((acc, cur, curIndex) => {
-    const last = curIndex > 1 ? acc[curIndex - 1] : ''
-    const newPath = last + '/' + cur
-    acc.push(newPath)
-    return acc
-  }, [])
-  return links
 }

--- a/app/src/components/Footer/Footer.tsx
+++ b/app/src/components/Footer/Footer.tsx
@@ -57,7 +57,7 @@ const FooterNav = styled.nav`
   display: block;
 `
 
-export const Footer = () => {
+export const Footer = ({ breadCrumbs }) => {
   const shopData = useShopData()
   const footerLinks = shopData?.siteSettings?.links ?? []
   const mailerTitle = shopData?.siteSettings?.mailerTitle ?? ''
@@ -66,7 +66,7 @@ export const Footer = () => {
   const router = useRouter()
   return (
     <FooterWrapper>
-      <Breadcrumbs />
+      <Breadcrumbs paths={breadCrumbs} />
       <FooterInner>
         <FooterLinks>
           {footerLinks.map((link) =>

--- a/app/src/components/Navigation/Navigation.tsx
+++ b/app/src/components/Navigation/Navigation.tsx
@@ -30,10 +30,9 @@ import { NavigationInner } from './NavigationInner'
 import { CurrencySelector } from './CurrencySelector'
 import { QuickLinks } from './QuickLinks'
 import { Breadcrumbs } from '../Footer/Breadcrumbs'
-import { search } from '@algolia/autocomplete-plugin-recent-searches'
-const { useEffect, useState, useRef, useCallback } = React
+const { useEffect, useRef  } = React
 
-export const Navigation = () => {
+export const Navigation = ({breadCrumbs}) => {
   const {
     closeAll,
     cartOpen,
@@ -120,7 +119,7 @@ export const Navigation = () => {
           </ToolsWrapper>
         </Inner>
         <BreadcrumbsWrapper>
-          {!searchOpen && <Breadcrumbs display={'header'} />}
+          {!searchOpen && <Breadcrumbs paths={breadCrumbs} display={'header'}/>}
         </BreadcrumbsWrapper>
         {showQuickLinks(router) ? <QuickLinks colorTheme={colorTheme} /> : null}
       </Wrapper>

--- a/app/src/components/Search/SearchPane.tsx
+++ b/app/src/components/Search/SearchPane.tsx
@@ -23,7 +23,7 @@ import { Footer } from '../Footer'
 
 const { useEffect } = React
 
-export const SearchPane = () => {
+export const SearchPane = ({ breadCrumbs }) => {
   const {
     open,
     loading,
@@ -204,7 +204,7 @@ export const SearchPane = () => {
           </Results>
         )}
         <div hidden={!open}>
-          <Footer />
+          <Footer {...breadCrumbs} />
         </div>
       </Wrapper>
     </Outer>

--- a/app/src/hooks/useBreadcrumbs.tsx
+++ b/app/src/hooks/useBreadcrumbs.tsx
@@ -253,7 +253,7 @@ export const useBreadcrumbs = () => {
       setCrumbs(crumbs)
     }
     fetchCrumbs()
-  }, [router.asPath])
+  }, [router.pathname])
 
   return crumbs
 }

--- a/app/src/hooks/useBreadcrumbs.tsx
+++ b/app/src/hooks/useBreadcrumbs.tsx
@@ -1,0 +1,259 @@
+import * as React from 'react'
+import gql from 'graphql-tag'
+import { useRouter } from 'next/router'
+import { Product, Collection, Page, JournalEntry } from '../types'
+
+import { request } from '../graphql'
+
+const { useState, useEffect } = React
+
+const productQuery = gql`
+  query ProductsPageQuery($handle: String) {
+    allProduct(where: { handle: { eq: $handle }, archived: { neq: true } }) {
+      __typename
+      _id
+      _key
+      shopifyId
+      title
+      handle
+      collections {
+        __typename
+        _id
+        _key
+        title
+        handle
+        shopifyId
+      }
+    }
+  }
+`
+const collectionQuery = gql`
+  query CollectionQuery($handle: String) {
+    allCollection(where: { handle: { eq: $handle }, archived: { neq: true } }) {
+      __typename
+      _id
+      _type
+      _key
+      title
+      handle
+      archived
+      shopifyId
+    }
+  }
+`
+const pageQuery = gql`
+  query PageQuery($slug: String!) {
+    allPage(where: { slug: { current: { eq: $slug } } }) {
+      __typename
+      title
+      subtitle
+      slug {
+        current
+      }
+    }
+  }
+`
+const journalEntryQuery = gql`
+  query JournalEntryQuery($slug: String) {
+    allJournalEntry(where: { slug: { current: { eq: $slug } } }) {
+      _id
+      _type
+      title
+      subtitle
+      slug {
+        current
+      }
+    }
+  }
+`
+
+interface Response {
+  allProduct: Product[]
+  allCollection: Collection[]
+  allPage: Page[]
+  allJournalEntry: JournalEntry[]
+}
+interface BreadcrumbsProps {
+  display?: string
+}
+
+interface BreadcrumbProps {
+  route: string
+  label: string
+  link: string
+}
+
+const Route2LabelMap = {
+  '/': 'Home',
+  '/404': 'Page Not Found',
+  '/about': 'About',
+  '/about/contact': 'Contact',
+  '/about/faq': 'FAQ',
+  '/about/appointments': 'Appointments',
+  '/about/team': 'Team',
+  '/blogs': 'Blog',
+  '/collections': 'Collections',
+  '/customize': 'Customize',
+  '/journal': 'Journal',
+  '/pages': 'Pages',
+  '/pages/[slug]': 'Page Not Found',
+  '/products': 'Collection',
+  '/customize/quiz': 'Quiz',
+  '/about/financing': 'Financing',
+}
+
+export const useBreadcrumbs = () => {
+  const router = useRouter()
+  const [crumbs, setCrumbs] = useState([])
+  const storage = globalThis?.sessionStorage
+  const getProduct = async () => {
+    const handle = router?.query.productSlug
+    const variables = { handle }
+    const [response] = await Promise.all([
+      request<Response>(productQuery, variables),
+    ])
+    const products = response?.allProduct
+    const product = products && products.length ? products[0] : null
+    return product
+  }
+  const getCollection = async (handle) => {
+    const variables = { handle }
+    const [response] = await Promise.all([
+      request<Response>(collectionQuery, variables),
+    ])
+    const collections = response?.allCollection
+    const collection = collections && collections.length ? collections[0] : null
+    return collection
+  }
+  const getPage = async (slug) => {
+    const variables = { slug }
+    const [response] = await Promise.all([
+      request<Response>(pageQuery, variables),
+    ])
+    const pages = response?.allPage
+    const page = pages && pages.length ? pages[0] : null
+    return page
+  }
+  const getJournalEntry = async (slug) => {
+    const variables = { slug }
+    const [response] = await Promise.all([
+      request<Response>(journalEntryQuery, variables),
+    ])
+    const entries = response?.allJournalEntry
+    const entry = entries && entries.length ? entries[0] : null
+    return entry
+  }
+
+  useEffect(() => {
+    const segmentsPath = router.asPath.split('/')
+    const segmentsRoute = router.route.split('/')
+    const crumbLinks = CombineAccumulatively(segmentsPath)
+    const crumbLabels = CombineAccumulatively(segmentsRoute)
+
+    // console.log('segmentsPath', segmentsPath)
+    // console.log('crumbLinks', crumbLinks)
+    // console.log('segmentsRoute', segmentsRoute)
+    // console.log('crumbLabels', crumbLabels)
+
+    function CombineAccumulatively(segments) {
+      const links = segments.reduce((acc, cur, curIndex) => {
+        const last = curIndex > 1 ? acc[curIndex - 1] : ''
+        const newPath = last + '/' + cur
+        acc.push(newPath)
+        return acc
+      }, [])
+      return links
+    }
+
+    const fetchCrumbs = async () => {
+      switch (segmentsRoute[1]) {
+        case 'products':
+          const product = await getProduct()
+          if (
+            typeof storage.prevPath !== 'undefined' &&
+            storage.prevPath.split('/')[1] == 'collections'
+          ) {
+            const segmentsPrevPath = storage.prevPath.split('/')
+            const productCollection = await getCollection(segmentsPrevPath[2])
+            const collectionLink =
+              `/collections/${segmentsPrevPath[2]}` ||
+              '/collections/newarrivals'
+            const collectionLabel = productCollection?.title || 'Collection'
+            crumbLinks.splice(1, 1, collectionLink)
+            crumbLabels.splice(1, 1, collectionLabel)
+          } else {
+            const collection =
+              product?.collections && product?.collections.length
+                ? product.collections[0]
+                : null
+            const collectionLink =
+              collection !== null
+                ? `/collections/${collection.handle}`
+                : '/collections/newarrivals'
+            const collectionLabel =
+              collection !== null ? collection.title : 'Collection'
+            crumbLinks.splice(1, 1, collectionLink)
+            crumbLabels.splice(1, 1, collectionLabel)
+          }
+          crumbLabels[2] = product?.title || 'Product'
+          break
+        case 'collections':
+          const handle = router.query?.collectionSlug
+          const collection = handle ? await getCollection(handle) : null
+          crumbLinks.splice(1, 1)
+          crumbLabels.splice(1, 1)
+          crumbLabels[1] = collection?.title
+          break
+        case 'about':
+          if (segmentsPath[2] === 'financing') {
+            crumbLabels[2] = 'Financing'
+          } else if (
+            segmentsPath[2] === 'issues-we-care-about' ||
+            segmentsPath[2] === 'product-sourcing'
+          ) {
+            crumbLinks.splice(1, 1, '/about/our-values')
+            crumbLabels.splice(1, 1, 'Our Values')
+            const page = await getPage(router.query?.pageSlug)
+            crumbLabels[2] = page?.title
+          } else {
+            if (
+              segmentsRoute.length > 2 &&
+              segmentsRoute[2] !== 'contact' &&
+              segmentsRoute[2] !== 'faq' &&
+              segmentsRoute[2] !== 'appointments' &&
+              segmentsRoute[2] !== 'team'
+            ) {
+              const page = await getPage(router.query?.pageSlug)
+              crumbLabels[2] = page?.title
+            }
+          }
+          break
+        case 'journal':
+          if (segmentsRoute.length > 2) {
+            const journal = await getJournalEntry(router.query?.entrySlug)
+            crumbLabels[2] = journal?.title
+          }
+          break
+        case '':
+          crumbLinks.splice(1, 1)
+          crumbLabels.splice(1, 1)
+          break
+        default:
+      }
+
+      const crumbs = crumbLinks.map((link, index) => {
+        const route = crumbLabels[index]
+        const crumb = {
+          link: link,
+          route: route,
+          label: Route2LabelMap[route] || route,
+        }
+        return crumb
+      })
+      setCrumbs(crumbs)
+    }
+    fetchCrumbs()
+  }, [router.asPath])
+
+  return crumbs
+}


### PR DESCRIPTION
- moves `breadCrumbs` data fetch to `useBreadcrumbs` hook in app folder, passes breadcrumb paths to nav and footer as props
- limits breadcrumb rerenders on variant change by changing useEffect dependency from `router.asPath` to `router.pathname`