### PR TITLE
feat(app): data optimizations

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -51,6 +51,7 @@ module.exports = withSourceMaps({
   },
   experimental: {
     scrollRestoration: true,
+    optimisticClientCache: false,
   },
   // webpack5: false,
   publicRuntimeConfig: {

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -114,6 +114,16 @@ module.exports = withSourceMaps({
           },
         ],
       },
+      {
+        source: '/:all*(svg|jpg|jpeg|png|webp|woff2|otf|woff|)',
+        locale: false,
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, must-revalidate',
+          },
+        ],
+      },
     ]
   },
   webpack: (config, { isServer, buildId }) => {

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -63,8 +63,6 @@ const App = (props: AppProps) => {
     storage.setItem('currentPath', globalThis.location.pathname)
   }
 
-  console.log('query test:', router.query)
-
   const breadCrumbs = useBreadcrumbs()
 
   if (!shopData) return null

--- a/app/src/components/Product/ProductThumbnail.tsx
+++ b/app/src/components/Product/ProductThumbnail.tsx
@@ -406,11 +406,11 @@ export const ProductThumbnail = ({
     } else {
       setVariantAnimation(undefined)
     }
-    // console.log('currentVariant:', currentVariant)
-    // console.log('currentSwatchOption:', currentSwatchOption)
   }, [currentVariant])
 
   useEffect(() => {
+    if (!router.isReady) return
+
     const collectionHandle = router.query.collectionSlug
     const currentVariantId = currentVariant?.id
     if (!currentVariantId) return
@@ -419,6 +419,7 @@ export const ProductThumbnail = ({
       collectionHandle as string,
       currentVariantId,
     )
+
     if (variantPriceInfo?.price) {
       setCurrentPrice(variantPriceInfo?.price)
     } else {
@@ -439,7 +440,6 @@ export const ProductThumbnail = ({
     }
     if (!currentVariantId && product.shopifyId) {
       getProductPriceById(product?.shopifyId).then((price) => {
-        console.log('productPriceInfo', price)
         if (price?.price) {
           setCurrentPrice(price?.price)
           console.log('SET PRICE TO PRODUCT PRICE (NO VARIANTS)', price)
@@ -457,31 +457,10 @@ export const ProductThumbnail = ({
   }, [
     currentVariant,
     currentCountry,
-    router.query,
-    getVariantPriceByCollection,
-    getVariantPriceBySearchResults,
+    router.isReady,
     product.shopifyId,
-    getProductPriceById,
+    getVariantPriceByCollection,
   ])
-
-  useEffect(() => {
-    // declare the async data fetching function
-    const fetchData = async () => {
-      if (!product?.shopifyId || !currentVariant?.shopifyVariantID) return
-      // get the data from the api
-      const variantPrice = await getVariantPriceById(
-        product.shopifyId,
-        currentVariant?.shopifyVariantID,
-      )
-      // set state with the result if `isSubscribed` is true
-      variantPrice?.price && setCurrentPrice(variantPrice?.price)
-      variantPrice?.compareAtPrice &&
-        setCurrentCompareAtPrice(variantPrice?.compareAtPrice)
-    }
-    // call the function
-    fetchData().catch(console.error)
-    // cancel any future `setData`
-  }, [currentVariant, product, currentCountry, getVariantPriceById])
 
   const handleClick = () => {
     // @ts-ignore

--- a/app/src/components/Product/ProductThumbnail.tsx
+++ b/app/src/components/Product/ProductThumbnail.tsx
@@ -368,6 +368,7 @@ export const ProductThumbnail = ({
     sendProductClick({ product, variant: currentVariant })
   }
   const allImages = useMemo(() => uniqueImages(variants), [variants])
+
   useEffect(() => {
     if (!isInViewOnce) return
     // @ts-ignore
@@ -595,19 +596,19 @@ export const ProductThumbnail = ({
       >
         {variantAnimation ? (
           <VideoWrapper hide={!playing} carousel={carousel} hover={imageHover}>
-            {imageHover && currentSwatchOption?.hover_image && (
-              <HoverThumbWrapper>
-                <Image
-                  image={currentSwatchOption?.hover_image}
-                  ratio={imageRatio || 1}
-                  sizes="(min-width: 1200px) 30vw, (min-width: 1000px) 50vw, 90vw"
-                  preload
-                  altText={altText}
-                  preloadImages={allImages}
-                  objectFit="cover"
-                />
-              </HoverThumbWrapper>
-            )}
+            <HoverThumbWrapper
+              hover={Boolean(imageHover && currentSwatchOption?.hover_image)}
+            >
+              <Image
+                image={currentSwatchOption?.hover_image}
+                ratio={imageRatio || 1}
+                sizes="(min-width: 1200px) 30vw, (min-width: 1000px) 50vw, 90vw"
+                preload
+                altText={altText}
+                preloadImages={allImages}
+                objectFit="cover"
+              />
+            </HoverThumbWrapper>
 
             <CloudinaryAnimation
               video={variantAnimation}
@@ -618,20 +619,18 @@ export const ProductThumbnail = ({
           </VideoWrapper>
         ) : null}
         <ImageWrapper hide={Boolean(variantAnimation)} hover={imageHover}>
-          {imageHover && currentSwatchOption?.hover_image && (
-            // <HoverThumb src={currentSwatchOption?.hover_image.asset?.url} />
-            <HoverThumbWrapper>
-              <Image
-                image={currentSwatchOption?.hover_image}
-                ratio={imageRatio || 1}
-                sizes="(min-width: 1200px) 30vw, (min-width: 1000px) 50vw, 90vw"
-                preload
-                altText={altText}
-                preloadImages={allImages}
-              />
-            </HoverThumbWrapper>
-          )}
-
+          <HoverThumbWrapper
+            hover={Boolean(imageHover && currentSwatchOption?.hover_image)}
+          >
+            <Image
+              image={currentSwatchOption?.hover_image}
+              ratio={imageRatio || 1}
+              sizes="(min-width: 1200px) 30vw, (min-width: 1000px) 50vw, 90vw"
+              preload
+              altText={altText}
+              preloadImages={allImages}
+            />
+          </HoverThumbWrapper>
           <Image
             image={productImage}
             ratio={imageRatio || 1}

--- a/app/src/components/Product/styled.ts
+++ b/app/src/components/Product/styled.ts
@@ -4,6 +4,10 @@ interface BackgroundImageProps {
   imageSrc: string
 }
 
+interface HoverThumbWrapperProps {
+  hover: boolean
+}
+
 export const ProductThumb = styled.div`
   ${({ theme }) => css`
     position: relative;
@@ -106,11 +110,23 @@ export const HoverThumb = styled.img`
   height: 100%;
 `
 
-export const HoverThumbWrapper = styled.div`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
+export const HoverThumbWrapper = styled.div<HoverThumbWrapperProps>`
+  ${({ hover, theme }) => css`
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    visibility: ${hover ? 'visible' : 'hidden'};
+    opacity: ${hover ? 1 : 0};
+
+    transition: 0.2s opacity ease-out,
+      0s visibility ease-in-out ${hover ? '0s' : '0.2s'};
+
+    ${theme.mediaQueries.mobile} {
+      visibility: hidden;
+      opacity: 0;
+    }
+  `}
 `
 
 interface WithHideCarousel {

--- a/app/src/providers/ShopifyPriceProvider/ShopifyPriceProvider.tsx
+++ b/app/src/providers/ShopifyPriceProvider/ShopifyPriceProvider.tsx
@@ -139,7 +139,6 @@ export const ShopifyPriceProvider = ({ children, query }: Props) => {
     variantId: string,
   ): Price | null => {
     if (!collectionHandle) return null
-    if (currentCountry == 'US') return null
     if (!currentCollectionPrices) return null
 
     const findVariant = currentCollectionPrices.products.edges
@@ -148,7 +147,7 @@ export const ShopifyPriceProvider = ({ children, query }: Props) => {
       })
       ?.node.variants.edges.filter((v) => v.node.id == variantId)[0].node
 
-    console.log('FIND VARIANT:', findVariant)
+    // console.log('FIND VARIANT:', findVariant)
     return {
       price: findVariant?.price,
       compareAtPrice: findVariant?.compareAtPrice,


### PR DESCRIPTION
- adds caching for all static assets (fixes reloading of fonts): [4e0651b](https://github.com/beelaineo/spinellikilcollin.com/pull/366/commits/4e0651b9402a4372762f0d8c7699fae7553cf149)
- turn off optimistic client cache to prevent fetching data on link hover: https://github.com/vercel/next.js/discussions/40268
- changes thumbnail hover effect to fade in/out and not re-render on each hover interaction: [a32b720](https://github.com/beelaineo/spinellikilcollin.com/pull/366/commits/a32b7206f36a277594edb1e5e959336ea06b5e4f)
---
- reverts recently updated change to use `getVariantPriceById` back to `getVariantPriceByCollection.` There are a ton of requests for each item when loading in a collection, and this method should just do one request on page load. @beelaineo  could you see any reason why reverting this would be an issue? I traced the update back to this part of the global-e updates: https://github.com/beelaineo/spinellikilcollin.com/pull/335/commits/08258d1969e26d3c71b9462d104b1a4b7ac6ad1b