### PR TITLE
fix(app): search results bugs

### DIFF
--- a/app/pages/api/algoliaIndex.ts
+++ b/app/pages/api/algoliaIndex.ts
@@ -228,9 +228,9 @@ const handler: NextApiHandler = (req, res) =>
       algoliaIndex.setSettings({
         searchableAttributes: [
           'title',
+          '_tags',
           'optionNames',
           'hidden',
-          '_tags',
           'description,optionDescriptions',
         ],
       })

--- a/app/src/providers/SearchProvider/reducer.ts
+++ b/app/src/providers/SearchProvider/reducer.ts
@@ -194,29 +194,28 @@ export const useSearchReducer = () => {
     startSearch(newSearchTerm)
     const term = searchTerm.trim()
 
-    const searchWithAdditionalMatches = (search) => {
-      const matches = {
-        rose: 'rg',
-        black: 'bg',
-        yellow: 'yg',
-      }
+    // const searchWithAdditionalMatches = (search) => {
+    //   const matches = {
+    //     rose: 'rg',
+    //     black: 'bg',
+    //     yellow: 'yg',
+    //   }
 
-      const additionalMatches = Object.entries(matches)
-        .map(([key, value]) => {
-          return search && search.includes(key) && value
-        })
-        .filter(Boolean)
+    //   const additionalMatches = Object.entries(matches)
+    //     .map(([key, value]) => {
+    //       return search && search.includes(key) && value
+    //     })
+    //     .filter(Boolean)
 
-      return additionalMatches.length
-        ? search.concat(' ', additionalMatches.join(' '))
-        : search
-    }
-
-    const termWithMatches = searchWithAdditionalMatches(term)
+    //   return additionalMatches.length
+    //     ? search.concat(' ', additionalMatches.join(' '))
+    //     : search
+    // }
 
     // const termSingular = term.replace(/s$/, '')
     // const params = { searchTerm: term, searchTermSingular: termSingular }
-    const { hits } = await algoliaIndex.search<SearchHit>(termWithMatches, {
+
+    const { hits } = await algoliaIndex.search<SearchHit>(term, {
       hitsPerPage: 100,
       typoTolerance: 'min',
       exactOnSingleWordQuery: 'word',

--- a/app/src/providers/ShopifyPriceProvider/ShopifyPriceProvider.tsx
+++ b/app/src/providers/ShopifyPriceProvider/ShopifyPriceProvider.tsx
@@ -155,7 +155,7 @@ export const ShopifyPriceProvider = ({ children, query }: Props) => {
   }
 
   const getVariantPriceBySearchResults = (variantId: string): Price | null => {
-    if (currentCountry == 'US') return null
+    // if (currentCountry == 'US') return null
     if (!currentSearchResultPrices) return null
 
     const findVariant = currentSearchResultPrices


### PR DESCRIPTION
- fixes hidden us currency on search variants
- fixes search relevancy on certain terms...in this case, `bg` for "black gold" was being appended to the search term anytime the word black was used in the search, from previous settings to increase specificity. I've removed these appended matches since I don't think they are useful anymore with the current search settings, and also create issues with search terms such as `black diamonds`.