### PR TITLE
fix(app): reload product page if data is stale on navigation

### DIFF
--- a/app/src/utils/useProductVariant.ts
+++ b/app/src/utils/useProductVariant.ts
@@ -58,10 +58,10 @@ export const useProductVariant = (
     // console.log('convertedVariantId', convertedVariantId)
     // console.log('variants in function', variants)
 
-    if (!variant)
-      throw new Error(
-        `There is no variant with the id "${variantId}" on the product ${product.title}`,
-      )
+    if (!variant) return variants[0]
+    // throw new Error(
+    //   `There is no variant with the id "${variantId}" on the product ${product.title}`,
+    // )
     return variant
   }
 

--- a/app/src/views/ProductDetail/ProductDetail.tsx
+++ b/app/src/views/ProductDetail/ProductDetail.tsx
@@ -112,6 +112,13 @@ const showInStockIndicators = SHOW_IN_STOCK_INDICATORS === 'true'
 export const ProductDetail = ({ product }: Props) => {
   const { openCustomizationModal } = useModal()
   const router = useRouter()
+
+  React.useEffect(() => {
+    if (product?.handle !== router.query.productSlug) {
+      router.reload()
+    }
+  }, [product?.handle, router])
+
   const params = new URLSearchParams(router.asPath.replace(/^(.*)\?/, ''))
   const variantId = params.get('v')
   const useProductVariantOptions = variantId


### PR DESCRIPTION
in some cases, product page data does not update properly when navigating forward and backward between products, crashing the page because of a mismatch between product and current variant data. In instances where page data is stale and the router has updated, this fix refreshes the router if `product.handle !== router.query.productSlug`.