### PR TITLE
fix(app): flatten ads query param with array

### DIFF
--- a/app/src/components/Filter/Filter.tsx
+++ b/app/src/components/Filter/Filter.tsx
@@ -256,8 +256,7 @@ export const Filter = ({
       const getKeys = matches?.map((match, i) => {
         const type = getFilterSetQueryType(items, match[0])
 
-        //@ts-ignore
-        const matchArr = match[1]?.split(' ')
+        const matchArr = (match as string[]).flat()[1]?.split(' ')
 
         const matchKeys = matchArr?.map((item) => {
           return {


### PR DESCRIPTION
closes #381 

---
crashes on prod: https://www.spinellikilcollin.com/collections/best-sellers?utm_source=Google+Ads&utm_medium=Smart+Search&utm_campaign=Best+Sellers&gad_source=1&gbraid=0AAAAACU1zOjByZq08HTzOP_AKDgI913C6&gclid=CjwKCAjw4_K0BhBsEiwAfVVZ_4tCCXHrA5MM8MARJOjJYPrzHHEWW0DpDIdxYoe3_6GuarBOQuq6QhoC7AUQAvD_BwE,%20to:%20/collections/best-sellers?utm_source=Google+Ads&utm_medium=Smart+Search&utm_campaign=Best+Sellers&gad_source=1&gbraid=0AAAAACU1zOjByZq08HTzOP_AKDgI913C6&gclid=CjwKCAjw4_K0BhBsEiwAfVVZ_4tCCXHrA5MM8MARJOjJYPrzHHEWW0DpDIdxYoe3_6GuarBOQuq6QhoC7AUQAvD_BwE

fixed on preview: https://spinellikilcollin-git-fix-google-ads-504cf1-spinelli-kilcollin.vercel.app/collections/best-sellers?utm_source=Google+Ads&utm_medium=Smart+Search&utm_campaign=Best+Sellers&gad_source=1&gbraid=0AAAAACU1zOjByZq08HTzOP_AKDgI913C6&gclid=CjwKCAjw4_K0BhBsEiwAfVVZ_4tCCXHrA5MM8MARJOjJYPrzHHEWW0DpDIdxYoe3_6GuarBOQuq6QhoC7AUQAvD_BwE,%20to:%20/collections/best-sellers?utm_source=Google+Ads&utm_medium=Smart+Search&utm_campaign=Best+Sellers&gad_source=1&gbraid=0AAAAACU1zOjByZq08HTzOP_AKDgI913C6&gclid=CjwKCAjw4_K0BhBsEiwAfVVZ_4tCCXHrA5MM8MARJOjJYPrzHHEWW0DpDIdxYoe3_6GuarBOQuq6QhoC7AUQAvD_BwE