### PR TITLE
feat(app): expand contact page functionality

### DIFF
--- a/app/src/views/ContactView/Contact.tsx
+++ b/app/src/views/ContactView/Contact.tsx
@@ -129,6 +129,31 @@ export const ContactView = ({ contact }: ContactProps) => {
                       </Heading>
                     </ContactLineWrapper>
                   )
+                case 'Email':
+                  return (
+                    <ContactLineWrapper key={_key}>
+                      <Heading level={4}>{label}</Heading>
+                      <Heading level={3}>
+                        <a href={'mailto:' + contact}>{contact}</a>
+                      </Heading>
+                    </ContactLineWrapper>
+                  )
+                case 'Customer Care':
+                  return (
+                    <ContactLineWrapper key={_key}>
+                      <Heading level={4}>{label}</Heading>
+                      <Heading level={3}>
+                        <a href={'tel:' + contact}>{contact}</a>
+                      </Heading>
+                      <Button
+                        level={2}
+                        onClick={handleModalClick('Engagement')}
+                        aria-label={label}
+                      >
+                        Contact Us
+                      </Button>
+                    </ContactLineWrapper>
+                  )
                 default:
                   return null
               }

--- a/app/src/views/ContactView/Contact.tsx
+++ b/app/src/views/ContactView/Contact.tsx
@@ -147,7 +147,7 @@ export const ContactView = ({ contact }: ContactProps) => {
                       </Heading>
                       <Button
                         level={2}
-                        onClick={handleModalClick('Engagement')}
+                        onClick={handleModalClick('Client Care')}
                         aria-label={label}
                       >
                         Contact Us

--- a/sanity/schemas/documents/contact.ts
+++ b/sanity/schemas/documents/contact.ts
@@ -22,7 +22,7 @@ export const contactLine = defineType({
       title: 'Line type',
       type: 'string',
       options: {
-        list: ['Order', 'Wholesale', 'Press', 'Engagement', 'Telephone'],
+        list: ['Order', 'Wholesale', 'Press', 'Engagement', 'Telephone', 'Email', 'Customer Care'],
       },
       validation: (Rule) => Rule.required(),
     }),


### PR DESCRIPTION
adds two new additional line-types to contact page contact lines:
1. email
2. customer care - adds customer care modal link after contact line

---

<img width="967" alt="Screenshot 2024-07-31 at 7 05 41 PM" src="https://github.com/user-attachments/assets/23df3b4a-6e53-40a0-b668-3b9cb173a7c9">
