### PR TITLE
(fix): remove listItem from RichText component

### DIFF
--- a/app/src/components/RichText/RichText.tsx
+++ b/app/src/components/RichText/RichText.tsx
@@ -135,7 +135,6 @@ export const RichText = ({
   article,
 }: RichTextProps) => {
 
-  console.log('bodybody', body)
   const currentProductContext = useCurrentProduct()
   const currentProduct = currentProductContext?.product
   const currentVariant = currentProductContext?.currentVariant

--- a/app/src/components/RichText/RichText.tsx
+++ b/app/src/components/RichText/RichText.tsx
@@ -169,9 +169,32 @@ export const RichText = ({
       },
       action: ({ children, value }) => {
         const { actionType } = value
+
         const onClick =
           actionType === 'openCart'
-            ? openCart
+            ? () => openCart()
+            : actionType === 'launchHubspot'
+            ? () => openHubspotChat()
+            : actionType === 'launchCustomizationModal'
+            ? () => openCustomizationModalWithProduct()
+            : actionType === 'launchRingSizerModal'
+            ? () => openRingSizerModalWithProduct()
+            : null
+        if (!actionType) {
+          return <>{children}</>
+        }
+        return (
+          <Span role="button" tabIndex={0} cursor="pointer" onClick={onClick}>
+            {children}
+          </Span>
+        )
+      },
+      textAction: ({ children, value }) => {
+        const { actionType } = value
+
+        const onClick =
+          actionType === 'openCart'
+            ? () => openCart()
             : actionType === 'launchHubspot'
             ? () => openHubspotChat()
             : actionType === 'launchCustomizationModal'

--- a/app/src/components/RichText/RichText.tsx
+++ b/app/src/components/RichText/RichText.tsx
@@ -134,7 +134,6 @@ export const RichText = ({
   weight,
   article,
 }: RichTextProps) => {
-
   const currentProductContext = useCurrentProduct()
   const currentProduct = currentProductContext?.product
   const currentVariant = currentProductContext?.currentVariant

--- a/app/src/components/RichText/RichText.tsx
+++ b/app/src/components/RichText/RichText.tsx
@@ -134,6 +134,8 @@ export const RichText = ({
   weight,
   article,
 }: RichTextProps) => {
+
+  console.log('bodybody', body)
   const currentProductContext = useCurrentProduct()
   const currentProduct = currentProductContext?.product
   const currentVariant = currentProductContext?.currentVariant
@@ -247,7 +249,6 @@ export const RichText = ({
       number: ({ children }) => <Ol>{children}</Ol>,
       bullet: ({ children }) => <Ul>{children}</Ul>,
     },
-    listItem: ({ value }) => <Li weight={3} {...value} />,
   }
 
   return body ? (

--- a/app/src/components/RichText/RichText.tsx
+++ b/app/src/components/RichText/RichText.tsx
@@ -39,6 +39,12 @@ const RichTextWrapper = styled.div<WithArticle>`
       margin: 80px auto;
     }
 
+    ul {
+      font-weight: 300;
+      line-height: 1.4em;
+      font-size: 5;
+    }
+
     h2:has(a) {
       width: fit-content;
       margin: 2 auto 0.5em;


### PR DESCRIPTION
- removes `listItem` from `RichText` components
- adds `textAction` to `RichText` components list, addresses warning in console: `Unknown mark type "textAction", please specify a serializer for it in the `serializers.marks` prop`
<img width="654" alt="image" src="https://github.com/user-attachments/assets/ccbaafe1-9abb-4d3c-8d21-c92eaba2c60a">
