### PR TITLE
fix(app): select preset collection if custom collection is empty

### DIFF
--- a/app/src/components/Carousel/SuggestedProductsCarousel.tsx
+++ b/app/src/components/Carousel/SuggestedProductsCarousel.tsx
@@ -285,19 +285,30 @@ export const SuggestedProductsCarousel = ({
       (v: any) => !v?.title.includes(product?.title),
     )
 
-    const uniqueVariantsSet = new Set()
+    const uniqueVariantSet = variantsWithoutCurrent.reduce((acc, current) => {
+      const options = current.sourceData.selectedOptions
 
-    const uniqueVariants = variantsWithoutCurrent.filter((item) => {
-      if (
-        uniqueVariantsSet.has(item.product.title) ||
-        item.product.title === product.title
-      ) {
-        return false
-      } else {
-        uniqueVariantsSet.add(item.product.title)
-        return true
+      const currentStyle = currentVariant?.sourceData?.selectedOptions?.find(
+        (option) => option?.name === 'Style',
+      )?.value
+      const currentColor = currentVariant?.sourceData?.selectedOptions?.find(
+        (option) => option?.name === 'Color',
+      )?.value
+
+      const style = options.find((option) => option.name === 'Style')?.value
+      const color = options.find((option) => option.name === 'Color')?.value
+
+      const uniqueCurrentKey = currentStyle || currentColor
+      const uniqueKey = style || color
+
+      if (uniqueKey !== uniqueCurrentKey && !acc.has(uniqueKey)) {
+        acc.set(uniqueKey, current)
       }
-    })
+
+      return acc
+    }, new Map())
+
+    const uniqueVariants = Array.from(uniqueVariantSet.values())
 
     setVariants(uniqueVariants as Maybe<ShopifyProductVariant>[])
   }, [data, currentVariant])

--- a/app/src/components/Carousel/SuggestedProductsCarousel.tsx
+++ b/app/src/components/Carousel/SuggestedProductsCarousel.tsx
@@ -1,19 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import { gql } from 'graphql-tag'
-import {
-  Collection,
-  Product,
-  ShopifyProductVariant,
-  ShopifySourceProductVariant,
-} from '../../types'
+import { Collection, Product, ShopifyProductVariant } from '../../types'
 import { Carousel } from './Carousel'
 import { ProductThumbnail } from '../Product'
-import { definitely, getVariantTitle, useViewportSize } from '../../utils'
-import {
-  useLazyRequest,
-  shopifyImageFragment,
-  shopifyVariantImageFragment,
-} from '../../graphql'
+import { definitely, useViewportSize } from '../../utils'
+import { useLazyRequest, shopifyVariantImageFragment } from '../../graphql'
 import { Maybe } from 'yup'
 
 //if collection then collection else prroducttype, then dollars within a range?
@@ -294,7 +285,21 @@ export const SuggestedProductsCarousel = ({
       (v: any) => !v?.title.includes(product?.title),
     )
 
-    setVariants(variantsWithoutCurrent as Maybe<ShopifyProductVariant>[])
+    const uniqueVariantsSet = new Set()
+
+    const uniqueVariants = variantsWithoutCurrent.filter((item) => {
+      if (
+        uniqueVariantsSet.has(item.product.title) ||
+        item.product.title === product.title
+      ) {
+        return false
+      } else {
+        uniqueVariantsSet.add(item.product.title)
+        return true
+      }
+    })
+
+    setVariants(uniqueVariants as Maybe<ShopifyProductVariant>[])
   }, [data, currentVariant])
 
   const filteredProducts = variants

--- a/app/src/views/ProductDetail/components/ProductRelated.tsx
+++ b/app/src/views/ProductDetail/components/ProductRelated.tsx
@@ -23,7 +23,7 @@ const getCarousel = (product: Product): CarouselType | Collection | null => {
   const { related, collections } = product
 
   if (related) {
-    if (related.items) return related
+    if (related.items.length) return related
     if (related.collection) return related.collection
   }
   if (collections && collections.length) return collections[0]

--- a/app/src/views/ProductDetail/components/ProductRelated.tsx
+++ b/app/src/views/ProductDetail/components/ProductRelated.tsx
@@ -23,7 +23,7 @@ const getCarousel = (product: Product): CarouselType | Collection | null => {
   const { related, collections } = product
 
   if (related) {
-    if (related.items.length) return related
+    if (related?.items?.length) return related
     if (related.collection) return related.collection
   }
   if (collections && collections.length) return collections[0]


### PR DESCRIPTION
- the carousel array of variants was showing up as empty instead of null on /anaka-earring, this additionally skips the custom collection if the array is empty.
- i noticed many of the carousel items, especially earrings, were repeating titles. this removes duplicates of a certain product if they do not differ in style or color.