### PR TITLE
fix(app): fix large related products queries

### DIFF
--- a/app/src/components/Carousel/SuggestedProductsCarousel.tsx
+++ b/app/src/components/Carousel/SuggestedProductsCarousel.tsx
@@ -73,8 +73,16 @@ const queryByCollection = gql`
 `
 
 const queryByProductType = gql`
-  query CarouselSuggestedProductsQuery($productType: ID!) {
-    allProducts(where: { store: { productType: { eq: $productType } } }) {
+  query CarouselSuggestedProductsQuery($productType: String!) {
+    allProduct(
+      where: {
+        hideFromSearch: { neq: true }
+        archived: { neq: true }
+        hidden: { neq: true }
+        hideFromCollections: { neq: true }
+        store: { productType: { eq: $productType } }
+      }
+    ) {
       __typename
       _id
       _key
@@ -129,7 +137,7 @@ const queryByProductType = gql`
 
 interface Response {
   allCollection: Collection[]
-  allProducts: Collection[]
+  allProduct: Collection[]
 }
 interface Variables {
   collectionId?: string | null | undefined
@@ -165,13 +173,13 @@ export const SuggestedProductsCarousel = ({
 
   useEffect(() => {
     if (Boolean(data)) return
-    if (!variables.collectionId) return
+    if (!variables) return
     getCarousel(variables)
   }, [data])
 
   const fetchedCollection: any = collection?._id
     ? data?.allCollection[0]?.products
-    : data?.allProducts[0]
+    : data?.allProduct
 
   const products = definitely(fetchedCollection)
 

--- a/app/src/views/ProductDetail/components/ProductRelated.tsx
+++ b/app/src/views/ProductDetail/components/ProductRelated.tsx
@@ -20,13 +20,12 @@ interface ProductRelatedProps {
 }
 
 const getCarousel = (product: Product): CarouselType | Collection | null => {
-  const { related, collections } = product
+  const { related } = product
 
   if (related) {
     if (related?.items?.length) return related
     if (related.collection) return related.collection
   }
-  if (collections && collections.length) return collections[0]
   return null
 }
 
@@ -35,35 +34,36 @@ export const ProductRelated = ({
   currentVariant,
 }: ProductRelatedProps) => {
   const carousel = getCarousel(product)
-  if (!carousel) return null
+
   const linkAs =
-    carousel.__typename === 'Collection'
-      ? `/collections/${carousel.handle}`
+    carousel?.__typename === 'Collection'
+      ? `/collections/${carousel?.handle}`
       : ''
+
   return (
     <ProductRelatedWrapper>
-      {carousel.__typename === 'Collection' ? (
+      {carousel?.__typename === 'Collection' ? (
         <Heading level={4} m={3} textTransform="capitalize" textAlign="center">
           <Link href="/collections/[collectionSlug]" as={linkAs}>
-            {carousel.title || 'More like this'}
+            {carousel?.title || 'More like this'}
           </Link>
         </Heading>
       ) : (
         <Heading level={4} m={3} textTransform="capitalize" textAlign="center">
-          {carousel.title || 'More like this'}
+          {carousel?.title || 'More like this'}
         </Heading>
       )}
       <ProductRelatedInner>
-        {carousel.__typename === 'Carousel' &&
-        carousel.items &&
-        carousel.items.length ? (
-          <ItemsCarousel items={carousel.items} />
+        {carousel?.__typename === 'Carousel' &&
+        carousel?.items &&
+        carousel?.items.length ? (
+          <ItemsCarousel items={carousel?.items} />
         ) : (
           <SuggestedProductsCarousel
             collection={
-              carousel.__typename === 'Carousel' && carousel.collection
-                ? carousel.collection
-                : carousel.__typename === 'Collection'
+              carousel?.__typename === 'Carousel' && carousel?.collection
+                ? carousel?.collection
+                : carousel?.__typename === 'Collection'
                 ? carousel
                 : null
             }


### PR DESCRIPTION
When a collection was not defined in sanity, the related products carousel was selecting the first collection listed on shopify. If this selected the rings collection, there is no way to limit the query size since its pulling in the whole collection. To fix this, if no collection is defined in sanity for the related products carousel, we are now pulling data from the product type and limiting the selection based on:

```
hideFromSearch: { neq: true }
archived: { neq: true }
hidden: { neq: true }
hideFromCollections: { neq: true }
```

Additionally, if the query becomes too large again, we can now limit the number of product matches for the query. For now I will leave it all products of a certain type since it is currently tested and working.
